### PR TITLE
Fix the CIDMap being generated with incorrect bucket lengths

### DIFF
--- a/src/templates/char_to_cid_beg.txt
+++ b/src/templates/char_to_cid_beg.txt
@@ -8,8 +8,7 @@
 /CIDInit /ProcSet findresource begin
 12 dict begin
 begincmap
-/CIDSystemInfo
-3 dict dup begin
+/CIDSystemInfo 3 dict dup begin
 /Registry (Adobe) def
 /Ordering (Identity) def
 /Supplement 0 def
@@ -20,6 +19,6 @@ end def
 /WMode 0 def
 2 begincodespacerange
 <20> <20>
-<0000> <19FF>
+<0000> <FFFF>
 endcodespacerange
 1469 begincidchar

--- a/src/templates/gid_to_unicode_beg.txt
+++ b/src/templates/gid_to_unicode_beg.txt
@@ -1,14 +1,24 @@
 /CIDInit /ProcSet findresource begin
+
 12 dict begin
+
 begincmap
-/CIDSystemInfo
-<< /Registry (FontSpecific)
-/Ordering ({0})
-/Supplement 0
->> def
+
+%!PS-Adobe-3.0 Resource-CMap
+%%DocumentNeededResources: procset CIDInit
+%%IncludeResource: procset CIDInit
+
+/CIDSystemInfo 3 dict dup begin
+    /Registry (FontSpecific) def
+    /Ordering ({0}) def
+    /Supplement 0 def
+end def
+
 /CMapName /FontSpecific-{0} def
+/CMapVersion 1 def
 /CMapType 2 def
+/WMode 0 def
+
 1 begincodespacerange
 <0000> <FFFF>
 endcodespacerange
-1 beginbfchar

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,1 +1,0 @@
-//! Make doc tests!


### PR DESCRIPTION
For some reason, I thought that the `<int> beginbfchar` was just an ever-increasing ID until someone pointed out that it's actually the number of the following GID->Unicode mappings.

This should fix any problems with copy & paste mistakes. Does not break any APIs.