### PR TITLE
Add function to create images from `DynamicImage`s

### DIFF
--- a/src/types/plugins/graphics/two_dimensional/image.rs
+++ b/src/types/plugins/graphics/two_dimensional/image.rs
@@ -3,7 +3,7 @@
 
 extern crate image;
 
-use image::ImageDecoder;
+use image::{ImageDecoder, DynamicImage};
 use Mm;
 use {ImageXObject, PdfLayerReference};
 
@@ -31,6 +31,15 @@ impl Image {
     -> Result<Self, image::ImageError>
     {
         let image = ImageXObject::try_from(image)?;
+        Ok(Self {
+            image: image,
+        })
+    }
+
+    pub fn try_from_image(image: &DynamicImage)
+    -> Result<Self, image::ImageError>
+    {
+        let image = ImageXObject::try_from_image(image)?;
         Ok(Self {
             image: image,
         })

--- a/src/types/plugins/graphics/xobject.rs
+++ b/src/types/plugins/graphics/xobject.rs
@@ -3,7 +3,7 @@
 
 use lopdf;
 use std::collections::HashMap;
-use image::{ImageError, ImageDecoder};
+use image::{ImageError, ImageDecoder, DynamicImage, GenericImage};
 use chrono::DateTime;
 use chrono::offset::utc::UTC;
 use {
@@ -193,6 +193,29 @@ impl ImageXObject {
             color_space: color_space,
             bits_per_component: color_bits,
             image_data: cur_data,
+            interpolate: true,
+            image_filter: None,
+            clipping_bbox: None,
+        })
+    }
+
+    pub fn try_from_image(image: &DynamicImage)
+    -> Result<Self, ImageError>
+    {
+        use image::DecodingResult;
+
+        let dim = image.dimensions();
+        let color_type = image.color();
+        let data = image.raw_pixels();
+        let color_bits = ColorBits::from(color_type);
+        let color_space = ColorSpace::from(color_type);
+
+        Ok(Self {
+            width: Px(dim.0 as usize),
+            height: Px(dim.1 as usize),
+            color_space: color_space,
+            bits_per_component: color_bits,
+            image_data: data,
             interpolate: true,
             image_filter: None,
             clipping_bbox: None,


### PR DESCRIPTION
Hello! I am working on a [markdown to pdf converter][mdproof], and am using `printpdf` to generate the pdf.

[mdproof]: https://github.com/Geemili/mdproof

This pull request  adds in the ability to use a `DynamicImage` that is already in memory to create a `printpdf::Image`. I load the images while I'm laying the pages out, so it seems redundant to parse the image again.

Fonts in `printpdf` have a similar API, and if you accept this pull request I plan on submitting another for fonts. Or, I could expand this pull request to include fonts as well.