### PR TITLE
Add std::error::Error impl for printpdf::Error

### DIFF
--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -96,3 +96,16 @@ impl fmt::Display for Error {
         }
     }
 }
+
+impl IError for Error {
+    fn description(&self) -> &str {
+        use self::Error::*;
+        match self {
+            Io(ref e) => e.description(),
+            Rusttype(ref e) => e.description(),
+            Pdf(ref e) => e.description(),
+            Index(ref e) => e.description(),
+        }
+    }
+}
+


### PR DESCRIPTION
I just started using this library as part of a larger project and noticed there was no implementation of `std::error::Error` in the code, although the internals are all there.
I've added it in with this PR. I can't imagine there could be any bugs associated, but if so, let me know.