### PR TITLE
Fix issue with embedded fonts on macOS and iOS

### DIFF
--- a/src/types/plugins/graphics/two_dimensional/font.rs
+++ b/src/types/plugins/graphics/two_dimensional/font.rs
@@ -172,7 +172,6 @@ impl ExternalFont {
         let font_stream = LoStream::new(
             LoDictionary::from_iter(vec![
                 ("Length1", Integer(font_buf_ref.len() as i64)),
-                ("Subtype", Name("CidFontType2".into())),
                 ]),
             font_buf_ref.to_vec())
         .with_compression(false); /* important! font stream must not be compressed! */
@@ -332,7 +331,7 @@ impl ExternalFont {
         ]);
 
         let font_bbox = vec![ Integer(0), Integer(max_height as i64), Integer(total_width as i64), Integer(max_height as i64) ];
-        font_descriptor_vec.push(("FontFile3".into(), Reference(doc.add_object(font_stream))));
+        font_descriptor_vec.push(("FontFile2".into(), Reference(doc.add_object(font_stream))));
 
         // although the following entry is technically not needed, Adobe Reader needs it
         font_descriptor_vec.push(("FontBBox".into(), Array(font_bbox)));


### PR DESCRIPTION
This fixes an issue with the fonts not displaying correctly on macOS and iOS.

I had an issue with embedded fonts displaying correctly on macOS and the file also failed to validate on https://www.pdf-online.com/osa/validate.aspx.

I think this fixes #26.

According to the [PDF Specification](https://www.adobe.com/content/dam/acom/en/devnet/pdf/PDF32000_2008.pdf) (page 289, Table 126) the previously used `FontFile3` is for CFF fonts. `FontFile2` is correct for TrueType fonts. A `Subtype` on the stream object isn't needed.
