### PR TITLE
Allow users to reduce optimization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ jpeg_rayon = ["image/jpeg_rayon"]
 dxt = ["image/dxt"]
 dds = ["image/dds"]
 webp = ["image/webp"]
+less-optimization = []
 
 [badges]
 travis-ci = { repository = "fschutt/printpdf" }

--- a/src/types/pdf_document.rs
+++ b/src/types/pdf_document.rs
@@ -469,11 +469,11 @@ impl PdfDocumentReference {
         Ok(())
     }
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature="less-optimization"))]
     #[inline]
     fn optimize(_: &mut lopdf::Document) { }
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(all(not(debug_assertions), not(feature="less-optimization")))]
     #[inline]
     fn optimize(doc: &mut lopdf::Document)
     {

--- a/src/types/plugins/graphics/xobject.rs
+++ b/src/types/plugins/graphics/xobject.rs
@@ -31,7 +31,7 @@ pub enum XObject {
 
 impl XObject {
 
-    #[cfg(debug_assertions)]
+    #[cfg(any(debug_assertions, feature="less-optimization"))]
     #[inline]
     fn compress_stream(stream: lopdf::Stream)
     -> lopdf::Stream
@@ -39,7 +39,7 @@ impl XObject {
         stream
     }
 
-    #[cfg(not(debug_assertions))]
+    #[cfg(all(not(debug_assertions), not(feature="less-optimization")))]
     #[inline]
     fn compress_stream(mut stream: lopdf::Stream)
     -> lopdf::Stream


### PR DESCRIPTION
For many use cases pdfs are write once read many, but in my specific
case pdfs are written once and read roughly once or twice. I would
prefer to disable compression and other optimizations in some cases.

In addition to not compressing when debug assertions are enabled, some
compressions now are disabled when the feature "less-optimization" is
enabled.

If you're interested in merging I'll modify the docs.