### PR TITLE
Remove deps.rs badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 ﻿# printpdf
 
 [![Travis CI](https://travis-ci.org/fschutt/printpdf.svg?branch=master)](https://travis-ci.org/fschutt/printpdf) [![Appveyor](https://ci.appveyor.com/api/projects/status/2ioc0wopm5a8ixgm?svg=true)](https://ci.appveyor.com/project/fschutt/printpdf)
-[![Dependencies](https://deps.rs/repo/github/fschutt/printpdf/status.svg)](https://deps.rs/repo/github/fschutt/printpdf)
 
 `printpdf` is a library designed for creating printable PDF documents.
 


### PR DESCRIPTION
This is a minor pull request to fix an issue with the deps.rs badge in the README.

Unfortunately it seems that deps.rs is not maintained anymore (https://github.com/srijs/deps.rs/issues/40), and it has failed to keep up-to-date with the latest crates.io API, which has prevented it from analysing dependencies. It is potentially worth removing the badge until such a time that the leadership of the deps.rs project is clarified and changes are deployed.

As an aside, thank you for the work you've put into this project - I've been using printpdf for a little while now and it's been fantastic.