### PR TITLE
Use WinAnsiEncoding for built-in fonts

### DIFF
--- a/src/types/pdf_document.rs
+++ b/src/types/pdf_document.rs
@@ -202,6 +202,11 @@ impl PdfDocumentReference {
     }
 
     /// Add a built-in font to the document
+    ///
+    /// Built-in fonts can only be used to print characters that are supported by the
+    /// [Windows-1252][] encoding.  All other characters will be ignored.
+    ///
+    /// [Windows-1252]: https://en.wikipedia.org/wiki/Windows-1252
     pub fn add_builtin_font(&self, builtin_font: BuiltinFont)
     -> ::std::result::Result<IndirectFontRef, Error>
     {

--- a/src/types/pdf_layer.rs
+++ b/src/types/pdf_layer.rs
@@ -429,6 +429,11 @@ impl PdfLayerReference {
     }
 
     /// Add text to the file at the current position
+    ///
+    /// If the given font is a built-in font and the given text contains characters that are not
+    /// supported by the [Windows-1252][] encoding, these characters will be ignored.
+    ///
+    /// [Windows-1252]: https://en.wikipedia.org/wiki/Windows-1252
     #[inline]
     pub fn write_text<S>(&self, text: S, font: &IndirectFontRef)
     -> () where S: Into<String>
@@ -478,7 +483,9 @@ impl PdfLayerReference {
                     .flat_map(|x| vec!((x >> 8) as u8, (x & 255) as u8))
                     .collect::<Vec<u8>>()
             } else {
-                text.as_bytes().to_vec()
+                // For built-in fonts, we selected the WinAnsiEncoding, see the Into<LoDictionary>
+                // implementation for BuiltinFont.
+                lopdf::Document::encode_text(Some("WinAnsiEncoding"), &text)
             }
         };
 
@@ -502,6 +509,11 @@ impl PdfLayerReference {
     }
 
     /// Add text to the file, x and y are measure in millimeter from the bottom left corner
+    ///
+    /// If the given font is a built-in font and the given text contains characters that are not
+    /// supported by the [Windows-1252][] encoding, these characters will be ignored.
+    ///
+    /// [Windows-1252]: https://en.wikipedia.org/wiki/Windows-1252
     #[inline]
     pub fn use_text<S>(&self, text: S, font_size: i64,
                        x: Mm, y: Mm, font: &IndirectFontRef)


### PR DESCRIPTION
Previously, PdfLayerReference::write_text would use the UTF-8 encoding
for built-in fonts.  But the built-in fonts only support a very limited
set of encodings, see Appendix D of the PDF Reference [0].  When adding
the font to the PDF document, printpdf already selects the
WinAnsiEncoding (Windows-1252, see the Into<LoDictionary> implementation
for BuiltinFont).  This would lead to encoding issues for all non-ASCII
characters, see also issue #30.

With this patch, we use lopdf::Document::encode_text to encode the text
for built-in fonts with the WinAnsiEncoding.  This fixes the encoding
issues for built-in fonts.  Note that that function just drops
characters that are not supported by the encoding.

This patch also adds notes about this behaviour to the documentation of
the add_builtin_font, use_text and write_text methods.

Fixes #30.

[0] https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf