### PR TITLE
Change text operators to accept f64 instead of i64

### DIFF
--- a/examples/builtin_fonts.rs
+++ b/examples/builtin_fonts.rs
@@ -18,6 +18,6 @@ fn main() {
     let text = "Lorem ipsum";
 
     let font = doc.add_builtin_font(BuiltinFont::TimesBoldItalic).unwrap();
-    current_layer.use_text(text, 48, Mm(10.0), Mm(200.0), &font);
+    current_layer.use_text(text, 48.0, Mm(10.0), Mm(200.0), &font);
     doc.save(&mut BufWriter::new(File::create("test_builtin_fonts.pdf").unwrap())).unwrap();
 }

--- a/examples/fonts.rs
+++ b/examples/fonts.rs
@@ -15,7 +15,7 @@ fn main() {
     let font = doc.add_external_font(&mut font_reader).unwrap();
 
     // `use_text` is a wrapper around making a simple string
-    current_layer.use_text(text, 48, Mm(10.0), Mm(200.0), &font);
+    current_layer.use_text(text, 48.0, Mm(10.0), Mm(200.0), &font);
 
     // text fill color = blue
     let blue = Rgb::new(13.0 / 256.0, 71.0 / 256.0, 161.0 / 256.0, None);
@@ -31,11 +31,11 @@ fn main() {
  
         // setup the general fonts.
         // see the docs for these functions for details
-        current_layer.set_font(&font, 33);
+        current_layer.set_font(&font, 33.0);
         current_layer.set_text_cursor(Mm(10.0), Mm(100.0));
-        current_layer.set_line_height(33);
-        current_layer.set_word_spacing(3000);
-        current_layer.set_character_spacing(10);
+        current_layer.set_line_height(33.0);
+        current_layer.set_word_spacing(3000.0);
+        current_layer.set_character_spacing(10.0);
 
         // write two lines (one line break)
         current_layer.write_text(text, &font);
@@ -44,14 +44,14 @@ fn main() {
         current_layer.add_line_break();
 
         current_layer.set_text_rendering_mode(TextRenderingMode::FillStroke);
-        current_layer.set_character_spacing(0);
+        current_layer.set_character_spacing(0.0);
         current_layer.set_text_matrix(TextMatrix::Rotate(10.0));
 
         // write one line, but write text2 in superscript
         current_layer.write_text(text, &font);
-        current_layer.set_line_offset(10);
+        current_layer.set_line_offset(10.0);
         current_layer.set_text_rendering_mode(TextRenderingMode::Stroke);
-        current_layer.set_font(&font, 18);
+        current_layer.set_font(&font, 18.0);
         current_layer.write_text(text2, &font);
 
     current_layer.end_text_section();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,7 +181,7 @@
 //! let font2 = doc.add_external_font(File::open("assets/fonts/RobotoMedium.ttf").unwrap()).unwrap();
 //!
 //! // text, font size, x from left edge, y from bottom edge, font
-//! current_layer.use_text(text, 48, Mm(200.0), Mm(200.0), &font);
+//! current_layer.use_text(text, 48.0, Mm(200.0), Mm(200.0), &font);
 //!
 //! // For more complex layout of text, you can use functions
 //! // defined on the PdfLayerReference
@@ -191,11 +191,11 @@
 //!
 //!     // setup the general fonts.
 //!     // see the docs for these functions for details
-//!     current_layer.set_font(&font2, 33);
+//!     current_layer.set_font(&font2, 33.0);
 //!     current_layer.set_text_cursor(Mm(10.0), Mm(10.0));
-//!     current_layer.set_line_height(33);
-//!     current_layer.set_word_spacing(3000);
-//!     current_layer.set_character_spacing(10);
+//!     current_layer.set_line_height(33.0);
+//!     current_layer.set_word_spacing(3000.0);
+//!     current_layer.set_character_spacing(10.0);
 //!     current_layer.set_text_rendering_mode(TextRenderingMode::Stroke);
 //!
 //!     // write two lines (one line break)
@@ -206,7 +206,7 @@
 //!
 //!     // write one line, but write text2 in superscript
 //!     current_layer.write_text(text.clone(), &font2);
-//!     current_layer.set_line_offset(10);
+//!     current_layer.set_line_offset(10.0);
 //!     current_layer.write_text(text2.clone(), &font2);
 //!
 //! current_layer.end_text_section();

--- a/src/types/pdf_layer.rs
+++ b/src/types/pdf_layer.rs
@@ -124,7 +124,7 @@ impl PdfLayerReference {
     /// Set the current font, only valid in a `begin_text_section` to
     /// `end_text_section` block
     #[inline]
-    pub fn set_font(&self, font: &IndirectFontRef, font_size: i64)
+    pub fn set_font(&self, font: &IndirectFontRef, font_size: f64)
     -> ()
     {
         self.internal_add_operation(Operation::new("Tf",
@@ -317,9 +317,9 @@ impl PdfLayerReference {
     /// Sets the text line height inside a text block
     /// (must be called within `begin_text_block` and `end_text_block`)
     #[inline]
-    pub fn set_line_height(&self, height: i64) {
+    pub fn set_line_height(&self, height: f64) {
         self.internal_add_operation(Operation::new("TL",
-            vec![lopdf::Object::Integer(height)]
+            vec![lopdf::Object::Real(height)]
         ));
     }
 
@@ -327,9 +327,9 @@ impl PdfLayerReference {
     /// Values are given in points. A value of 3 (pt) will increase
     /// the spacing inside a word by 3pt.
     #[inline]
-    pub fn set_character_spacing(&self, spacing: i64) {
+    pub fn set_character_spacing(&self, spacing: f64) {
         self.internal_add_operation(Operation::new("Tc",
-            vec![lopdf::Object::Integer(spacing)]
+            vec![lopdf::Object::Real(spacing)]
         ));
     }
 
@@ -342,9 +342,9 @@ impl PdfLayerReference {
     /// However, the function itself is valid and _will work_
     /// with builtin fonts.
     #[inline]
-    pub fn set_word_spacing(&self, spacing: i64) {
+    pub fn set_word_spacing(&self, spacing: f64) {
         self.internal_add_operation(Operation::new("Tw",
-            vec![lopdf::Object::Integer(spacing)]
+            vec![lopdf::Object::Real(spacing)]
         ));
     }
 
@@ -353,9 +353,9 @@ impl PdfLayerReference {
     /// 50 will reduce the width of the written text by half,
     /// but stretch the text
     #[inline]
-    pub fn set_text_scaling(&self, scaling: i64) {
+    pub fn set_text_scaling(&self, scaling: f64) {
         self.internal_add_operation(Operation::new("Tz",
-            vec![lopdf::Object::Integer(scaling)]
+            vec![lopdf::Object::Real(scaling)]
         ));
     }
 
@@ -365,9 +365,9 @@ impl PdfLayerReference {
     /// number, for subscript, use a negative number. This does not
     /// change the size of the font
     #[inline]
-    pub fn set_line_offset(&self, offset: i64) {
+    pub fn set_line_offset(&self, offset: f64) {
         self.internal_add_operation(Operation::new("Ts",
-            vec![lopdf::Object::Integer(offset)]
+            vec![lopdf::Object::Real(offset)]
         ));
     }
 
@@ -515,7 +515,7 @@ impl PdfLayerReference {
     ///
     /// [Windows-1252]: https://en.wikipedia.org/wiki/Windows-1252
     #[inline]
-    pub fn use_text<S>(&self, text: S, font_size: i64,
+    pub fn use_text<S>(&self, text: S, font_size: f64,
                        x: Mm, y: Mm, font: &IndirectFontRef)
     -> () where S: Into<String>
     {


### PR DESCRIPTION
According to the PDF Reference [0], Table 5.2, all text state operators
accept numbers, that means reals or integers.  Currently, printpdf only
accepts integers (i64).  This is not sufficient for all use cases.  For
example, for printing justified text, users will want to have
fine-grained control over character and word spacing.

Therefore, this patch changes all text operation methods to accept
floats instead of integers (f64 instead of i64).

[0] https://www.adobe.com/content/dam/acom/en/devnet/pdf/pdfs/pdf_reference_archives/PDFReference.pdf

----

To make these functions easier to use, they could also accept `impl
Into<f64>` instead of `f64`.  Let me know if you want me to change that.