### PR TITLE
Use BTreeMap in FontList for reproducibility

### DIFF
--- a/src/types/plugins/graphics/two_dimensional/font.rs
+++ b/src/types/plugins/graphics/two_dimensional/font.rs
@@ -4,7 +4,7 @@
 use lopdf;
 use lopdf::{Stream as LoStream, Dictionary as LoDictionary};
 use lopdf::StringFormat;
-use std::collections::{HashMap, BTreeMap};
+use std::collections::BTreeMap;
 use std::iter::FromIterator;
 use Error;
 
@@ -381,7 +381,7 @@ impl PartialEq for ExternalFont {
 
 /// Indexed reference to a font that was added to the document
 /// This is a "reference by postscript name"
-#[derive(Debug, Hash, Eq, Clone, PartialEq)]
+#[derive(Debug, Hash, Eq, Ord, Clone, PartialEq, PartialOrd)]
 pub struct IndirectFontRef {
     /// Name of the font (postscript name)
     pub(crate) name: String,
@@ -411,7 +411,7 @@ impl IndirectFontRef {
 /// Font list for tracking fonts within a single PDF document
 #[derive(Default, Debug, Clone)]
 pub struct FontList {
-    fonts: HashMap<IndirectFontRef, DirectFontRef>,
+    fonts: BTreeMap<IndirectFontRef, DirectFontRef>,
 }
 
 impl FontList {


### PR DESCRIPTION
This patch replaces the HashMap in FontList with a BTreeMap so that the
fonts in the generated PDF document are added in sorted by their name.
This makes it easier to reproducibly generate PDF files e. g. in unit
tests.

To be able to use IndirectFontRef as the key of a BTreeMap, we also have
to derive Ord.