### PR TITLE
Add PdfDocumentReference::with_creation_date

### DIFF
--- a/src/types/pdf_document.rs
+++ b/src/types/pdf_document.rs
@@ -166,6 +166,17 @@ impl PdfDocumentReference {
         self
     }
 
+    /// Sets the creation date on the document.
+    ///
+    /// Per default, the creation date is set to the current time.
+    #[inline]
+    pub fn with_creation_date(self, creation_date: OffsetDateTime)
+    -> Self
+    {
+        self.document.borrow_mut().metadata.creation_date = creation_date;
+        self
+    }
+
     /// Sets the modification date on the document. Intended to be used when
     /// reading documents that already have a modification date.
     #[inline]


### PR DESCRIPTION
This patch adds the with_creation_date method to PdfDocumentReference
that sets the creation date in the PDF metadata.

Fixes #71.