### PR TITLE
Move font handling into FontData trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,7 +369,7 @@ pub use self::types::plugins::misc::document_info::DocumentInfo;
 /// Stub module for 3D content in a PDF
 pub use self::types::plugins::graphics::three_dimensional;
 pub use self::types::plugins::graphics::two_dimensional::font::{
-    Font, BuiltinFont, ExternalFont, TextRenderingMode, IndirectFontRef, DirectFontRef, FontList
+    Font, FontData, BuiltinFont, ExternalFont, TextRenderingMode, IndirectFontRef, DirectFontRef, FontList
 };
 pub use self::types::plugins::graphics::two_dimensional::image::Image;
 pub use self::types::plugins::graphics::two_dimensional::line::Line;

--- a/src/types/pdf_document.rs
+++ b/src/types/pdf_document.rs
@@ -12,7 +12,7 @@ use lopdf;
 use indices::*;
 use {
     ExternalFont, Font, PdfPage, FontList, IccProfileList, PdfMetadata, PdfConformance, IndirectFontRef,
-    DirectFontRef, BuiltinFont, PdfPageReference, Error, Mm
+    DirectFontRef, BuiltinFont, PdfPageReference, Error, Mm, FontData
 };
 
 /// PDF document
@@ -207,6 +207,19 @@ impl PdfDocumentReference {
     {
         let last_font_index = { let doc = self.document.borrow(); doc.fonts.len() };
         let external_font = ExternalFont::new(font_stream, last_font_index)?;
+        let external_font_name = external_font.face_name.clone();
+        let font = Font::ExternalFont(external_font);
+        implement_adding_fonts!(&self, external_font_name, font)
+    }
+
+    /// Add a font from a custom font backend
+    pub fn add_external_font_data<F>(&self, bytes: Vec<u8>, data: F)
+    -> ::std::result::Result<IndirectFontRef, Error>
+    where
+        F: FontData + 'static,
+    {
+        let last_font_index = { let doc = self.document.borrow(); doc.fonts.len() };
+        let external_font = ExternalFont::with_font_data(bytes, last_font_index, Box::new(data));
         let external_font_name = external_font.face_name.clone();
         let font = Font::ExternalFont(external_font);
         implement_adding_fonts!(&self, external_font_name, font)

--- a/src/types/pdf_layer.rs
+++ b/src/types/pdf_layer.rs
@@ -457,14 +457,12 @@ impl PdfLayerReference {
         // let mut kerning_data = Vec::<freetype::Vector>::new();
 
         let bytes: Vec<u8> = {
-            use rusttype::FontCollection;
             use rusttype::Codepoint as Cp;
 
             if let Font::ExternalFont(face_direct_ref) = doc.fonts.get_font(font).unwrap().data {
 
                 let mut list_gid = Vec::<u16>::new();
-                let collection = FontCollection::from_bytes(&*face_direct_ref.font_bytes).unwrap();
-                let font = collection.clone().into_font().unwrap_or(collection.font_at(0).unwrap());
+                let font = &face_direct_ref.font_data;
 
                 // convert into list of glyph ids - unicode magic
                 let char_iter = text.chars();

--- a/src/types/pdf_layer.rs
+++ b/src/types/pdf_layer.rs
@@ -457,24 +457,15 @@ impl PdfLayerReference {
         // let mut kerning_data = Vec::<freetype::Vector>::new();
 
         let bytes: Vec<u8> = {
-            use rusttype::Codepoint as Cp;
-
             if let Font::ExternalFont(face_direct_ref) = doc.fonts.get_font(font).unwrap().data {
 
                 let mut list_gid = Vec::<u16>::new();
                 let font = &face_direct_ref.font_data;
 
-                // convert into list of glyph ids - unicode magic
-                let char_iter = text.chars();
-
-                for ch in char_iter {
-                    // note: font.glyph will panic if the character is \0
-                    // since that can't happen in Rust, I think we're safe here
-                    let glyph = font.glyph(Cp(ch as u32));
-                    list_gid.push(glyph.id().0 as u16);
-
-                    // todo - kerning !!
-                    // font.pair_kerning(scale, id, base_glyph.id());
+                for ch in text.chars() {
+                    if let Some(glyph_id) = font.glyph_id(ch) {
+                        list_gid.push(glyph_id);
+                    }
                 }
 
                 list_gid.iter()

--- a/src/types/plugins/graphics/two_dimensional/font.rs
+++ b/src/types/plugins/graphics/two_dimensional/font.rs
@@ -84,8 +84,10 @@ impl Into<LoDictionary> for BuiltinFont {
 
 #[derive(Debug, Clone)]
 pub struct ExternalFont {
-    /// Font data
+    /// Raw font data
     pub(crate) font_bytes: Vec<u8>,
+    /// Parsed font data
+    pub(crate) font_data: rusttype::Font<'static>,
     /// Font name, for adding as a resource on the document
     pub(crate) face_name: String,
     /// Is the font written vertically? Default: false
@@ -138,14 +140,13 @@ impl ExternalFont {
         let mut buf = Vec::<u8>::new();
         font_stream.read_to_end(&mut buf)?;
 
-        let face_name = {
-            let collection = FontCollection::from_bytes(buf.clone())?;
-            collection.clone().into_font().unwrap_or(collection.font_at(0)?);
-            format!("F{}", font_index)
-        };
+        let collection = FontCollection::from_bytes(buf.clone())?;
+        let font = collection.font_at(0)?;
+        let face_name = format!("F{}", font_index);
 
         Ok(Self {
             font_bytes: buf,
+            font_data: font,
             face_name: face_name,
             vertical_writing: false,
         })

--- a/src/types/plugins/graphics/two_dimensional/font.rs
+++ b/src/types/plugins/graphics/two_dimensional/font.rs
@@ -9,8 +9,6 @@ use std::iter::FromIterator;
 use Error;
 
 use rusttype::FontCollection;
-use rusttype::Codepoint as Cp;
-use rusttype::GlyphId as Gid;
 
 /// The font
 #[derive(Debug, Clone, PartialEq)]
@@ -87,7 +85,7 @@ pub struct ExternalFont {
     /// Raw font data
     pub(crate) font_bytes: Vec<u8>,
     /// Parsed font data
-    pub(crate) font_data: rusttype::Font<'static>,
+    pub(crate) font_data: Box<dyn FontData>,
     /// Font name, for adding as a resource on the document
     pub(crate) face_name: String,
     /// Is the font written vertically? Default: false
@@ -141,12 +139,12 @@ impl ExternalFont {
         font_stream.read_to_end(&mut buf)?;
 
         let collection = FontCollection::from_bytes(buf.clone())?;
-        let font = collection.font_at(0)?;
+        let font = collection.clone().into_font().or_else(|_| collection.font_at(0))?;
         let face_name = format!("F{}", font_index);
 
         Ok(Self {
             font_bytes: buf,
-            font_data: font,
+            font_data: Box::new(font),
             face_name: face_name,
             vertical_writing: false,
         })
@@ -161,20 +159,14 @@ impl ExternalFont {
 
         let face_name = self.face_name.clone();
 
-        let font_buf_ref: Box<[u8]> = self.font_bytes.into_boxed_slice();
-        let collection = FontCollection::from_bytes(font_buf_ref.clone()).unwrap();
-        let font = collection.clone().into_font().unwrap_or_else(|_| {
-            collection.font_at(0).unwrap()
-        });
-
         // Extract basic font information
-        let face_metrics = font.v_metrics_unscaled();
+        let face_metrics = self.font_data.font_metrics();
 
         let font_stream = LoStream::new(
             LoDictionary::from_iter(vec![
-                ("Length1", Integer(font_buf_ref.len() as i64)),
+                ("Length1", Integer(self.font_bytes.len() as i64)),
                 ]),
-            font_buf_ref.to_vec())
+            self.font_bytes)
         .with_compression(false); /* important! font stream must not be compressed! */
 
         // Begin setting required font attributes
@@ -190,9 +182,9 @@ impl ExternalFont {
         let mut font_descriptor_vec: Vec<(::std::string::String, Object)> = vec![
             ("Type".into(), Name("FontDescriptor".into())),
             ("FontName".into(), Name(face_name.clone().into_bytes())),
-            ("Ascent".into(), Integer(face_metrics.ascent as i64)),
-            ("Descent".into(), Integer(face_metrics.descent as i64)),
-            ("CapHeight".into(), Integer(face_metrics.ascent as i64)),
+            ("Ascent".into(), Integer(i64::from(face_metrics.ascent))),
+            ("Descent".into(), Integer(i64::from(face_metrics.descent))),
+            ("CapHeight".into(), Integer(i64::from(face_metrics.ascent))),
             ("ItalicAngle".into(), Integer(0)),
             ("Flags".into(), Integer(32)),
             ("StemV".into(), Integer(80)),
@@ -212,33 +204,15 @@ impl ExternalFont {
         let mut cmap = BTreeMap::<u32, (u32, u32, u32)>::new();
         cmap.insert(0, (0, 1000, 1000));
 
-        for unicode in 0x0000..0xffff {
+        for (glyph_id, c) in self.font_data.glyph_ids() {
+            if let Some(glyph_metrics) = self.font_data.glyph_metrics(glyph_id) {
+                if glyph_metrics.height > max_height {
+                    max_height = glyph_metrics.height;
+                }
 
-            let glyph = font.glyph(Cp(unicode));
-
-            if glyph.id().0 == 0 {
-                continue;
-            }
-
-            let glyph_id = glyph.id().0;
-            let glyph = font.glyph(Gid(glyph_id));
-
-            if let Some(glyph_metrics) = glyph.standalone().get_data() {
-
-                let w = glyph_metrics.unit_h_metrics.advance_width;
-
-                // Note: extents can be None, but then the character may still have a
-                // horizontal advance!
-                let h = glyph_metrics.extents.and_then(|extents| {
-                    Some(extents.max.y - extents.min.y - face_metrics.descent as i32)
-                }).unwrap_or(1000);
-
-                if h > max_height {
-                    max_height = h;
-                };
-
-                total_width += w as u32;
-                cmap.insert(glyph_id, (unicode as u32, w as u32, h as u32));
+                total_width += glyph_metrics.width;
+                cmap.insert(glyph_id as u32,
+                            (c as u32, glyph_metrics.width as u32, glyph_metrics.height as u32));
             }
         }
 
@@ -293,7 +267,7 @@ impl ExternalFont {
         let mut current_width_vec = Vec::<Object>::new();
 
         // scale the font width so that it sort-of fits into an 1000 unit square
-        let percentage_font_scaling = 1000.0 / (font.units_per_em() as f64);
+        let percentage_font_scaling = 1000.0 / (face_metrics.units_per_em as f64);
 
         for (gid, width) in widths {
             if gid == current_high_gid {
@@ -479,5 +453,108 @@ impl FontList {
         }
 
         font_dict
+    }
+}
+
+/// The unscaled base metrics for a font provided by a [`FontData`](trait.FontData.html)
+/// implementation.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FontMetrics {
+    /// The ascent of the font.
+    pub ascent: i16,
+    /// The descent of the font.
+    pub descent: i16,
+    /// The units per em square for this font.
+    pub units_per_em: u16,
+}
+
+/// The metrics for a glyph provided by a [`FontData`](trait.FontData.html) implementation.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct GlyphMetrics {
+    /// The width of the glyph, typically the horizontal advance.
+    pub width: u32,
+    /// The height of the glyph, typically the difference between the ascent and the descent.
+    pub height: u32,
+}
+
+/// Provides access to font metrics.
+///
+/// Per default, printpdf uses [`rusttype`][] to extract the font data.  You can implement this
+/// trait for other types if you want to use a different font backend.
+///
+/// [`rusttype`]: https://docs.rs/rusttype/latest/rusttype/
+pub trait FontData: FontDataClone + std::fmt::Debug {
+    /// Returns the unscaled metrics for this font.
+    fn font_metrics(&self) -> FontMetrics;
+
+    /// Returns the glyph id for a Unicode character if it is present in this font.
+    fn glyph_id(&self, c: char) -> Option<u16>;
+
+    /// Returns a mapping from glyph IDs to Unicode characters for all supported characters.
+    fn glyph_ids(&self) -> std::collections::HashMap<u16, char>;
+
+    /// Returns the glyph metrics for a glyph of this font, if available.
+    fn glyph_metrics(&self, glyph_id: u16) -> Option<GlyphMetrics>;
+}
+
+impl FontData for rusttype::Font<'static> {
+    fn font_metrics(&self) -> FontMetrics {
+        let metrics = self.v_metrics_unscaled();
+        FontMetrics {
+            ascent: metrics.ascent as i16,
+            descent: metrics.descent as i16,
+            units_per_em: self.units_per_em(),
+        }
+    }
+
+    fn glyph_id(&self, c: char) -> Option<u16> {
+        let glyph_id = self.glyph(c).id().0;
+        if glyph_id == 0 {
+            None
+        } else {
+            Some(glyph_id as u16)
+        }
+    }
+
+    fn glyph_ids(&self) -> std::collections::HashMap<u16, char> {
+        let mut map = std::collections::HashMap::with_capacity(self.glyph_count());
+        for c in char::default()..std::char::MAX {
+            if let Some(glyph_id) = self.glyph_id(c) {
+                map.insert(glyph_id, c);
+            }
+        }
+        map
+    }
+
+    fn glyph_metrics(&self, glyph_id: u16) -> Option<GlyphMetrics> {
+        let glyph_id = rusttype::GlyphId(u32::from(glyph_id));
+        if let Some(glyph_metrics) = self.glyph(glyph_id).standalone().get_data() {
+            let width = glyph_metrics.unit_h_metrics.advance_width as u32;
+            let height = glyph_metrics.extents.and_then(|extents| {
+                let descent = self.v_metrics_unscaled().descent as i32;
+                Some((extents.max.y - extents.min.y - descent) as u32)
+            }).unwrap_or(1000);
+            Some(GlyphMetrics { width, height })
+        } else {
+            None
+        }
+    }
+}
+
+/// Helper trait for cloning boxed [`FontData`](trait.FontData.html) implementors.
+pub trait FontDataClone {
+    /// Clones this font data and returns a box with the cloned data.
+    fn clone_font_data(&self) -> Box<dyn FontData>;
+}
+
+impl<T: FontData + Clone + 'static> FontDataClone for T {
+    fn clone_font_data(&self) -> Box<dyn FontData> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn FontData> {
+    fn clone(&self) -> Box<dyn FontData> {
+        self.clone_font_data()
     }
 }


### PR DESCRIPTION
This PR moves the font handling into a new trait, FontData, that allows the user to use a custom font backend, see #75.  As far as I see, it does not change the existing public API.  Yet the new methods `add_external_font_data` and `with_font_data` are slightly different from the existing data becuase they accept a `Vec<u8>` instead of a `io::Read` implementation for the raw font data.  This is because the user must already have read the font data if they were able to parse it and construct a `FontData` instance from it.

My suggestions for the next steps:
- Replace `rusttype` 0.8 with either `ab_glyph` or `owned_ttf_parser`.  `rusttype` 0.9 moved to the `ttf-parser` crate.  With `ttf-parser`, iterating over all Unicode characters is extremely slow, especially in debug mode, see https://github.com/alexheretic/ab-glyph/issues/18.  The solution is either to use `ttf-parser` directly (`owned_ttf_parser` in this cause because `Box` requires a static lifetime), or `ab_glyph`, see the linked discussion.  Also, in `rusttype` 0.9, it is no longer possible to access the unscaled metrics, so moving to `ab_glyph` or `owned_ttf_parser` mitigates the need to un-scale the scaled metrics.
- Make that dependency optional so that users can opt out of the default font backend if they use something else.