### PR TITLE
Fix compiler warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ description = "Rust library for writing PDF files"
 [dependencies]
 lopdf = { version = "0.26", default-features = false }
 rusttype = { version = "0.8.2", default-features = false, features = ["std"] }
-time = { version = "0.2.1", default-features = false, features = ["std"] }
+time = { version = "0.2.11", default-features = false, features = ["std"] }
 log = { version = "0.4.8", optional = true }
 
 [dependencies.image]

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -43,18 +43,11 @@ pub enum PdfError {
 
 impl fmt::Display for PdfError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
+        write!(f, "Invalid or corrupt font face")
     }
 }
 
-impl IError for PdfError {
-    fn description(&self) -> &str {
-        use self::PdfError::*;
-        match *self {
-            FontFaceError => "Invalid or corrupt font face",
-        }
-    }
-}
+impl IError for PdfError {}
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum IndexError {
@@ -65,20 +58,16 @@ pub enum IndexError {
 
 impl fmt::Display for IndexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.description())
-    }
-}
-
-impl IError for IndexError {
-    fn description(&self) -> &str {
         use self::IndexError::*;
-        match *self {
+        write!(f, "{}", match *self {
             PdfPageIndexError => "Page index out of bounds",
             PdfLayerIndexError => "PDF layer index out of bounds",
             PdfMarkerIndexError => "PDF layer index out of bounds",
-        }
+        })
     }
 }
+
+impl IError for IndexError {}
 
 impl_from!(IoError, Error::Io);
 impl_from!(RusttypeError, Error::Rusttype);
@@ -97,15 +86,4 @@ impl fmt::Display for Error {
     }
 }
 
-impl IError for Error {
-    fn description(&self) -> &str {
-        use self::Error::*;
-        match self {
-            Io(ref e) => e.description(),
-            Rusttype(ref e) => e.description(),
-            Pdf(ref e) => e.description(),
-            Index(ref e) => e.description(),
-        }
-    }
-}
-
+impl IError for Error {}

--- a/src/types/pdf_metadata.rs
+++ b/src/types/pdf_metadata.rs
@@ -40,7 +40,7 @@ impl PdfMetadata {
 	pub fn new<S>(title: S, document_version: u32, trapping: bool, conformance: PdfConformance)
 	-> Self where S: Into<String>
 	{
-		let current_time = OffsetDateTime::now();
+		let current_time = OffsetDateTime::now_utc();
 
 		Self {
 			creation_date: current_time.clone(),


### PR DESCRIPTION
This PR fixes the compiler warnings caused by the `Error::description` implementations and the use of `OffsetDateTime::now`.