### PR TITLE
Add PdfDocumentReference::with_metadata_date

### DIFF
--- a/src/types/pdf_document.rs
+++ b/src/types/pdf_document.rs
@@ -184,6 +184,17 @@ impl PdfDocumentReference {
         self
     }
 
+    /// Sets the metadata date on the document.
+    ///
+    /// By default, the metadata date is set to the current time.
+    #[inline]
+    pub fn with_metadata_date(self, metadata_date: OffsetDateTime)
+    -> Self
+    {
+        self.document.borrow_mut().metadata.metadata_date = metadata_date;
+        self
+    }
+
     /// Sets the modification date on the document. Intended to be used when
     /// reading documents that already have a modification date.
     #[inline]


### PR DESCRIPTION
This patch adds the with_metadata_date method to PdfDocumentReference
that sets the metadata date in the PDF metadata.

This is similar to #74 (#71), and is also required to generate reproducible documents.