### PR TITLE
Replace rusttype with owned_ttf_parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,15 +13,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
-name = "approx"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,12 +423,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordered-float"
-version = "1.1.1"
+name = "owned_ttf_parser"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+checksum = "3a3c7a20e3f122223e68eef6ca58e39bc1ea8a1d83418ba4c2c1ba189d2ee355"
 dependencies = [
- "num-traits",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -460,7 +451,7 @@ dependencies = [
  "js-sys",
  "log",
  "lopdf",
- "rusttype",
+ "owned_ttf_parser",
  "time",
 ]
 
@@ -520,17 +511,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
-]
-
-[[package]]
-name = "rusttype"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f61411055101f7b60ecf1041d87fb74205fb20b0c7a723f07ef39174cf6b4c0"
-dependencies = [
- "approx",
- "ordered-float",
- "stb_truetype",
 ]
 
 [[package]]
@@ -607,15 +587,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf906c8b8fc3f6ecd1046e01da1d8ddec83e48c8b08b84dcc02b585a6bedf5a8"
 dependencies = [
  "version_check",
-]
-
-[[package]]
-name = "stb_truetype"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77b6b07e862c66a9f3e62a07588fee67cd90a9135a2b942409f195507b4fb51"
-dependencies = [
- "byteorder",
 ]
 
 [[package]]
@@ -726,6 +697,12 @@ dependencies = [
  "standback",
  "syn",
 ]
+
+[[package]]
+name = "ttf-parser"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c56097738aec26a3f347edf99f5c84d9d4e3a4b8ce5513ebca85cb621fc7c50"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["./assets/*", "./doc/*", "./examples/*"]
 
 [dependencies]
 lopdf = { version = "0.26", default-features = false }
-rusttype = { version = "0.8.2", default-features = false, features = ["std"] }
+owned_ttf_parser = "0.12"
 time = { version = "0.2.11", default-features = false, features = ["std"] }
 log = { version = "0.4.8", optional = true }
 

--- a/src/errors/mod.rs
+++ b/src/errors/mod.rs
@@ -2,7 +2,7 @@
 
 use std::error::Error as IError;
 use std::io::Error as IoError;
-use rusttype::Error as RusttypeError;
+use owned_ttf_parser::FaceParsingError;
 use std::fmt;
 
 /// error_chain and failure are certainly nice, but completely overengineered
@@ -28,8 +28,8 @@ macro_rules! impl_from {
 pub enum Error {
     /// External: std::io::Error
     Io(IoError),
-    /// External: rusttype::Error
-    Rusttype(RusttypeError),
+    /// External: owned_ttf_parser::FaceParsingError
+    FaceParsing(FaceParsingError),
     /// PDF error
     Pdf(PdfError),
     /// Indexing error (please report if this happens, shouldn't happen)
@@ -70,7 +70,7 @@ impl fmt::Display for IndexError {
 impl IError for IndexError {}
 
 impl_from!(IoError, Error::Io);
-impl_from!(RusttypeError, Error::Rusttype);
+impl_from!(FaceParsingError, Error::FaceParsing);
 impl_from!(PdfError, Error::Pdf);
 impl_from!(IndexError, Error::Index);
 
@@ -79,7 +79,7 @@ impl fmt::Display for Error {
         use self::Error::*;
         match *self {
             Io(ref e) => write!(f, "{}", e),
-            Rusttype(ref e) => write!(f, "{}", e),
+            FaceParsing(ref e) => write!(f, "{}", e),
             Pdf(ref e) => write!(f, "{}", e),
             Index(ref e) => write!(f, "{}", e),
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,7 +334,7 @@
 #[macro_use] pub extern crate log;
 
 pub extern crate lopdf;
-extern crate rusttype;
+extern crate owned_ttf_parser;
 extern crate time;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 extern crate js_sys;
@@ -356,7 +356,6 @@ pub use self::errors::Error;
 pub use self::errors::PdfError;
 pub use date::*;
 pub use self::errors::IndexError;
-pub use rusttype::Error as RusttypeError;
 
 pub use self::scale::{Mm, Pt, Px};
 pub use self::types::pdf_conformance::{CustomPdfConformance, PdfConformance};


### PR DESCRIPTION
Rusttype 0.8 is outdated and [no longer maintained](https://gitlab.redox-os.org/redox-os/rusttype/-/issues/148).  ab_glyph is its successor, but for printpdf’s use case, it is sufficient to use ttf-parser (or, more precisely, owned_ttf_parser) directly. 

Therefore, this patch replace rusttype with owned_ttf_parser.  Users with more advanced use cases can use other crates by  implementing printpdf’s `FontData` trait.

Fixes #75.

----

Maybe it would make sense to make owned_ttf_parser an optional dependency so that people who use their own `FontData` implementation don’t have to pull in owned_ttf_parser.