### PR TITLE
svg: improve bbox handling of generated PDF

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -3,6 +3,7 @@
 
 use crate::{Mm, PdfLayerReference, Px, XObject, XObjectRef};
 use lopdf::{Object, Stream};
+use std::{error, fmt};
 
 /// SVG - wrapper around an `XObject` to allow for more
 /// control within the library
@@ -24,6 +25,19 @@ pub enum SvgParseError {
     // PDF returned by pdf2svg is not in the expected form
     InternalError,
 }
+
+impl fmt::Display for SvgParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Svg2PdfConversionError(inner) => write!(f, "svg2pdf conversion error: {}", inner),
+            Self::PdfParsingError => write!(f, "error parsing svg2pdf pdf data"),
+            Self::NoContentStream => write!(f, "svg2pdf returned no content stream"),
+            Self::InternalError => write!(f, "pdf returned by pdf2svg in unexpected form"),
+        }
+    }
+}
+
+impl error::Error for SvgParseError {}
 
 /// Transform that is applied immediately before the
 /// image gets painted. Does not affect anything other


### PR DESCRIPTION
Some SVGs have fractional pixel bounding boxes, which we can safely
round up without the user noticing anything. In addition, previously
this code would use the width (x2) as both the height and width of the
bounding-box -- this is also rectified.

This is a rebase and re-application of commit d79c8a28764d ("svg:
improve bbox handling of generated PDF") which was accidentally reverted
by commit 80bf42ed74ad ("Reapply: "svg: implement std Error for
SvgParseError").

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>