### PR TITLE
Use reference instead of copy on converting OffsetDateTime to string

### DIFF
--- a/src/document_info.rs
+++ b/src/document_info.rs
@@ -74,8 +74,8 @@ impl DocumentInfo {
         let trapping = if m.trapping { "True" } else { "False" };
         let gts_pdfx_version = m.conformance.get_identifier_string();
 
-        let info_mod_date = to_pdf_time_stamp_metadata(m.modification_date);
-        let info_create_date = to_pdf_time_stamp_metadata(m.creation_date);
+        let info_mod_date = to_pdf_time_stamp_metadata(&m.modification_date);
+        let info_create_date = to_pdf_time_stamp_metadata(&m.creation_date);
 
         Dictionary(LoDictionary::from_iter(vec![
             ("Trapped", trapping.into()),
@@ -94,7 +94,7 @@ impl DocumentInfo {
 }
 
 // D:20170505150224+02'00'
-fn to_pdf_time_stamp_metadata(date: OffsetDateTime)
+fn to_pdf_time_stamp_metadata(date: &OffsetDateTime)
 -> String
 {
     // Since the time is in UTC, we know that the time zone

--- a/src/xmp_metadata.rs
+++ b/src/xmp_metadata.rs
@@ -46,9 +46,9 @@ impl XmpMetadata {
 
         // let xmp_instance_id = "2898d852-f86f-4479-955b-804d81046b19";
         let instance_id = random_character_string_32();
-        let create_date = to_pdf_xmp_date(m.creation_date);
-        let modification_date = to_pdf_xmp_date(m.modification_date);
-        let metadata_date = to_pdf_xmp_date(m.metadata_date);
+        let create_date = to_pdf_xmp_date(&m.creation_date);
+        let modification_date = to_pdf_xmp_date(&m.modification_date);
+        let metadata_date = to_pdf_xmp_date(&m.metadata_date);
 
         let pdf_x_version = m.conformance.get_identifier_string();
         let document_version = self.document_version.to_string();
@@ -87,7 +87,7 @@ impl XmpMetadata {
 }
 
 // D:2018-09-19T10:05:05+00'00'
-fn to_pdf_xmp_date(date: OffsetDateTime)
+fn to_pdf_xmp_date(date: &OffsetDateTime)
 -> String
 {
     // Since the time is in UTC, we know that the time zone


### PR DESCRIPTION
Hey,
the problem is that js_sys::Date does not implement the copy trait, therefore your OffsetDateTime polyfill for wasm in src/date.rs does not implement the copy trait. Therefore printpdf can't be build for wasm-unknown-unknown. I think the most simple fix is to change the function signatures for to_pdf_time_stamp_metadata and to_pdf_time_stamp_metadata to use a OffsetDateTime reference. A copy is not necessary anyway. Let me know if I'm wrong.

Thank you!
Jonas