### PR TITLE
Convert to edition 2018, apply rustfmt and fix clippy warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 target/*
 ./*.pdf
 ./test_
-test_
+test_*
 .vscode/*
 .cargo/*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "bitflags"
@@ -46,15 +46,15 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "c041d3eab048880cb0b86b256447da3f18859a163c3b8d8893f4e6368abe6393"
 
 [[package]]
 name = "byteorder"
@@ -112,26 +112,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -151,15 +149,6 @@ checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
 dependencies = [
  "adler32",
  "byteorder",
-]
-
-[[package]]
-name = "deflate"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86f7e25f518f4b81808a2cf1c50996a61f5c2eb394b2393bd87f2a4780a432f"
-dependencies = [
- "adler32",
 ]
 
 [[package]]
@@ -246,12 +235,12 @@ checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
 name = "flate2"
-version = "1.0.24"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.5.3",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -283,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
 ]
@@ -308,18 +297,18 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.3"
+version = "0.24.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e30ca2ecf7666107ff827a8e481de6a132a9b687ed3bb20bb1c144a36c00964"
+checksum = "69b7ea949b537b0fd0af141fff8c77690f2ce96f4f41f042ccb6c69c6c965945"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
  "gif",
- "jpeg-decoder 0.2.6",
+ "jpeg-decoder 0.3.0",
  "num-rational 0.4.1",
  "num-traits",
- "png 0.17.5",
+ "png 0.17.7",
  "scoped_threadpool",
  "tiff",
 ]
@@ -332,9 +321,9 @@ checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
 
 [[package]]
 name = "itoa"
-version = "1.0.3"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "jpeg-decoder"
@@ -344,18 +333,18 @@ checksum = "229d53d58899083193af11e15917b5640cd40b29ff475a1fe4ef725deb02d0f2"
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9478aa10f73e7528198d75109c8be5cd7d15fb530238040148d5f9a22d4c5b3b"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
 dependencies = [
  "rayon",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -377,9 +366,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.132"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "linked-hash-map"
@@ -416,24 +405,24 @@ dependencies = [
 
 [[package]]
 name = "matches"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "memmap2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95af15f345b17af2efc8ead6080fb8bc376f8cec1b35277b935637595fe77498"
+checksum = "4b182332558b18d807c4ce1ca8ca983b34c3ee32765e47b3f0f69b90355cc1dc"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -459,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -520,9 +509,9 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
  "hermit-abi",
  "libc",
@@ -530,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.1"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "owned_ttf_parser"
@@ -568,20 +557,20 @@ checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
 dependencies = [
  "bitflags",
  "crc32fast",
- "deflate 0.8.6",
+ "deflate",
  "miniz_oxide 0.3.7",
 ]
 
 [[package]]
 name = "png"
-version = "0.17.5"
+version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc38c0ad57efb786dd57b9864e5b18bae478c00c824dc55a38bbc9da95dde3ba"
+checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
  "bitflags",
  "crc32fast",
- "deflate 1.0.0",
- "miniz_oxide 0.5.3",
+ "flate2",
+ "miniz_oxide 0.6.2",
 ]
 
 [[package]]
@@ -592,9 +581,9 @@ checksum = "07e2192780e9f8e282049ff9bffcaa28171e1cb0844f49ed5374e518ae6024ec"
 
 [[package]]
 name = "printpdf"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
- "image 0.24.3",
+ "image 0.24.5",
  "js-sys",
  "log",
  "lopdf",
@@ -607,45 +596,43 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -695,9 +682,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "scoped_threadpool"
@@ -728,15 +715,15 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -745,11 +732,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
- "itoa 1.0.3",
+ "itoa 1.0.5",
  "ryu",
  "serde",
 ]
@@ -786,9 +773,9 @@ checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
 name = "smallvec"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
+checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "standback"
@@ -862,18 +849,18 @@ dependencies = [
 
 [[package]]
 name = "svgtypes"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc802f68b144cdf4d8ff21301f9a7863e837c627fde46537e29c05e8a18c85c1"
+checksum = "22975e8a2bac6a76bb54f898a6b18764633b00e780330f0b689f65afb3975564"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -882,12 +869,12 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7259662e32d1e219321eb309d5f9d898b779769d81b76e762c07c8e5d38fcb65"
+checksum = "7449334f9ff2baf290d55d73983a7d6fa15e01198faef72af07e2a8db851e471"
 dependencies = [
  "flate2",
- "jpeg-decoder 0.2.6",
+ "jpeg-decoder 0.3.0",
  "weezl",
 ]
 
@@ -937,9 +924,9 @@ checksum = "7ae2f58a822f08abdaf668897e96a5656fe72f5a9ce66422423e8849384872e6"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.8"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
+checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
 
 [[package]]
 name = "unicode-bidi-mirroring"
@@ -961,15 +948,15 @@ checksum = "07547e3ee45e28326cc23faac56d44f58f16ab23e413db526debce3b0bfd2742"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-script"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dd944fd05f2f0b5c674917aea8a4df6af84f2d8de3fe8d988b95d28fb8fb09"
+checksum = "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc"
 
 [[package]]
 name = "unicode-vo"
@@ -1012,9 +999,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1022,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
 dependencies = [
  "bumpalo",
  "log",
@@ -1037,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1047,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1060,9 +1047,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "weezl"
@@ -1094,9 +1081,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "xmlparser"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
+checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
 
 [[package]]
 name = "xmlwriter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,16 +11,26 @@ keywords = ["pdf", "gui", "graphics", "wkhtmltopdf"]
 categories = ["gui"]
 exclude = ["./assets/*", "./doc/*", "./examples/*"]
 autoexamples = false
+edition = "2018"
 
 [dependencies]
 # minimum dependencies
-lopdf = { version = "0.27.0", default-features = false, features = ["pom_parser"] }
+lopdf = { version = "0.27.0", default-features = false, features = [
+    "pom_parser",
+] }
 owned_ttf_parser = { version = "0.12", default-features = false }
 time = { version = "0.2.11", default-features = false, features = ["std"] }
 # optional: logging
 log = { version = "0.4.8", optional = true }
 # image reading (png / jpeg)
-image = { version = "0.24.3", optional = true, default-features = false, features = ["gif", "jpeg", "png", "pnm", "tiff", "bmp"] }
+image = { version = "0.24.3", optional = true, default-features = false, features = [
+    "gif",
+    "jpeg",
+    "png",
+    "pnm",
+    "tiff",
+    "bmp",
+] }
 # svg support (svg -> pdf xobject)
 svg2pdf = { version = "0.1.0", optional = true }
 pdf-writer = { version = "0.4.1", optional = true }
@@ -28,8 +38,6 @@ usvg = { version = "0.19.0", optional = true }
 
 [features]
 default = []
-# cargo clippy
-clippy = []
 # do not compress PDF streams, useful for debugging
 less-optimization = []
 # enables logging
@@ -47,10 +55,8 @@ webp = ["image/webp", "embedded_images"]
 # enables svg
 svg = ["svg2pdf", "usvg", "pdf-writer"]
 
-
 [package.metadata.docs.rs]
 all-features = true
-
 
 [target.'cfg(all(target_arch="wasm32",target_os="unknown"))'.dependencies]
 js-sys = "0.3.40"
@@ -61,40 +67,32 @@ appveyor = { repository = "fschutt/printpdf" }
 
 [[example]]
 name = "bookmark"
-default-features = false
 required-features = []
 
 [[example]]
 name = "circle"
-default-features = false
 required-features = []
 
 [[example]]
 name = "font"
-default-features = false
 required-features = []
 
 [[example]]
 name = "image"
-default-features = false
 required-features = ["embedded_images"]
 
 [[example]]
 name = "no_icc"
-default-features = false
 required-features = []
 
 [[example]]
 name = "page"
-default-features = false
 required-features = []
 
 [[example]]
 name = "shape"
-default-features = false
 required-features = []
 
 [[example]]
 name = "svg"
-default-features = false
 required-features = ["svg"]

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -5,25 +5,20 @@ use std::fs::File;
 use std::io::BufWriter;
 
 fn main() {
-
-    use printpdf::{
-        calculate_points_for_circle,
-        calculate_points_for_rect
-    };
-
-    let (doc, page1, layer1) = PdfDocument::new("printpdf circle test", Mm(210.0), Mm(297.0), "Layer 1");
+    let (doc, page1, layer1) =
+        PdfDocument::new("printpdf circle test", Mm(210.0), Mm(297.0), "Layer 1");
     let current_layer = doc.get_page(page1).get_layer(layer1);
 
     let radius = Pt(40.0);
     let offset_x = Pt(10.0);
     let offset_y = Pt(50.0);
 
-    let line = Line { 
-        points: calculate_points_for_circle(radius, offset_x, offset_y), 
-        is_closed: true, 
-        has_fill: true, 
+    let line = Line {
+        points: calculate_points_for_circle(radius, offset_x, offset_y),
+        is_closed: true,
+        has_fill: true,
         has_stroke: true,
-        is_clipping_path: false
+        is_clipping_path: false,
     };
 
     current_layer.add_shape(line);
@@ -33,15 +28,18 @@ fn main() {
     let offset_x_rect = Pt(20.0);
     let offset_y_rect = Pt(5.0);
 
-    let line = Line { 
-        points: calculate_points_for_rect(scale_x_rect, scale_y_rect, offset_x_rect, offset_y_rect), 
-        is_closed: true, 
-        has_fill: true, 
+    let line = Line {
+        points: calculate_points_for_rect(scale_x_rect, scale_y_rect, offset_x_rect, offset_y_rect),
+        is_closed: true,
+        has_fill: true,
         has_stroke: true,
-        is_clipping_path: false
+        is_clipping_path: false,
     };
 
     current_layer.add_shape(line);
 
-    doc.save(&mut BufWriter::new(File::create("test_circle.pdf").unwrap())).unwrap();
+    doc.save(&mut BufWriter::new(
+        File::create("test_circle.pdf").unwrap(),
+    ))
+    .unwrap();
 }

--- a/examples/font.rs
+++ b/examples/font.rs
@@ -4,13 +4,15 @@ use std::fs::File;
 use std::io::BufWriter;
 
 fn main() {
-    let (doc, page1, layer1) = PdfDocument::new("PDF_Document_title", Mm(500.0), Mm(300.0), "Layer 1");
+    let (doc, page1, layer1) =
+        PdfDocument::new("PDF_Document_title", Mm(500.0), Mm(300.0), "Layer 1");
     let current_layer = doc.get_page(page1).get_layer(layer1);
 
     let text = "Lorem ipsum";
     let text2 = "dolor sit amet";
 
-    let mut font_reader = std::io::Cursor::new(include_bytes!("../assets/fonts/RobotoMedium.ttf").as_ref());
+    let mut font_reader =
+        std::io::Cursor::new(include_bytes!("../assets/fonts/RobotoMedium.ttf").as_ref());
 
     let font = doc.add_external_font(&mut font_reader).unwrap();
 
@@ -28,7 +30,7 @@ fn main() {
     // Make sure to wrap your commands
     // in a `begin_text_section()` and `end_text_section()` wrapper
     current_layer.begin_text_section();
- 
+
     // setup the general fonts.
     // see the docs for these functions for details
     current_layer.set_font(&font, 33.0);
@@ -61,5 +63,6 @@ fn main() {
     let font = doc.add_builtin_font(BuiltinFont::TimesBoldItalic).unwrap();
     current_layer.use_text(text, 48.0, Mm(10.0), Mm(200.0), &font);
 
-    doc.save(&mut BufWriter::new(File::create("test_fonts.pdf").unwrap())).unwrap();
+    doc.save(&mut BufWriter::new(File::create("test_fonts.pdf").unwrap()))
+        .unwrap();
 }

--- a/examples/image.rs
+++ b/examples/image.rs
@@ -1,13 +1,14 @@
 extern crate printpdf;
 
-use printpdf::*;
-use std::io::Cursor;
 use image_crate::codecs::bmp::BmpDecoder;
+use printpdf::*;
 use std::fs::File;
 use std::io::BufWriter;
+use std::io::Cursor;
 
 fn main() {
-    let (doc, page1, layer1) = PdfDocument::new("printpdf graphics test", Mm(210.0), Mm(297.0), "Layer 1");
+    let (doc, page1, layer1) =
+        PdfDocument::new("printpdf graphics test", Mm(210.0), Mm(297.0), "Layer 1");
     let current_layer = doc.get_page(page1).get_layer(layer1);
 
     // currently, the only reliable file formats are bmp/jpeg/png
@@ -22,17 +23,21 @@ fn main() {
     let rotation_center_x = Px((image.image.width.0 as f64 / 2.0) as usize);
     let rotation_center_y = Px((image.image.height.0 as f64 / 2.0) as usize);
 
-    // layer,     
-    image.add_to_layer(current_layer.clone(), ImageTransform {
-        rotate: Some(ImageRotation {
-            angle_ccw_degrees: 45.0,
-            rotation_center_x,
-            rotation_center_y,
-        }),
-        translate_x: Some(Mm(10.0)),
-        translate_y: Some(Mm(10.0)),
-        .. Default::default()
-    });
+    // layer,
+    image.add_to_layer(
+        current_layer.clone(),
+        ImageTransform {
+            rotate: Some(ImageRotation {
+                angle_ccw_degrees: 45.0,
+                rotation_center_x,
+                rotation_center_y,
+            }),
+            translate_x: Some(Mm(10.0)),
+            translate_y: Some(Mm(10.0)),
+            ..Default::default()
+        },
+    );
 
-    doc.save(&mut BufWriter::new(File::create("test_image.pdf").unwrap())).unwrap();
+    doc.save(&mut BufWriter::new(File::create("test_image.pdf").unwrap()))
+        .unwrap();
 }

--- a/examples/no_icc.rs
+++ b/examples/no_icc.rs
@@ -8,17 +8,20 @@ use std::fs::File;
 use std::io::BufWriter;
 
 fn main() {
-
-	// This code creates the most minimal PDF file with 1.2 KB
-	// Currently, fonts need to use an embedded font, so if you need to write something, the file size
-	// will still be bloated (because of the embedded font)
-	// Also, OCG content is still enabled, even if you disable it here. 
-    let (mut doc, _page1, _layer1) = PdfDocument::new("printpdf no_icc test", Mm(297.0), Mm(210.0), "Layer 1");
+    // This code creates the most minimal PDF file with 1.2 KB
+    // Currently, fonts need to use an embedded font, so if you need to write something, the file size
+    // will still be bloated (because of the embedded font)
+    // Also, OCG content is still enabled, even if you disable it here.
+    let (mut doc, _page1, _layer1) =
+        PdfDocument::new("printpdf no_icc test", Mm(297.0), Mm(210.0), "Layer 1");
     doc = doc.with_conformance(PdfConformance::Custom(CustomPdfConformance {
-    	requires_icc_profile: false,
-    	requires_xmp_metadata: false,
-        .. Default::default()
+        requires_icc_profile: false,
+        requires_xmp_metadata: false,
+        ..Default::default()
     }));
 
-    doc.save(&mut BufWriter::new(File::create("test_no_icc.pdf").unwrap())).unwrap();
+    doc.save(&mut BufWriter::new(
+        File::create("test_no_icc.pdf").unwrap(),
+    ))
+    .unwrap();
 }

--- a/examples/page.rs
+++ b/examples/page.rs
@@ -9,12 +9,13 @@ fn main() {
     // You can later on add more pages with the add_page() function
     // You also have to specify the title of the PDF and the document creator
     let (doc, _, _) = PdfDocument::new("printpdf page test", Mm(210.0), Mm(297.0), "Layer 1");
-    
-    // You can add more pages and layers to the PDF. 
+
+    // You can add more pages and layers to the PDF.
     // Just make sure you don't lose the references, otherwise, you can't add things to the layer anymore
-    let (page2, _) = doc.add_page(Mm(297.0), Mm(210.0),"Page 2, Layer 1");
+    let (page2, _) = doc.add_page(Mm(297.0), Mm(210.0), "Page 2, Layer 1");
     let _ = doc.get_page(page2).add_layer("Layer 3");
 
     // If this is successful, you should see a PDF with two blank A4 pages
-    doc.save(&mut BufWriter::new(File::create("test_pages.pdf").unwrap())).unwrap();
+    doc.save(&mut BufWriter::new(File::create("test_pages.pdf").unwrap()))
+        .unwrap();
 }

--- a/examples/shape.rs
+++ b/examples/shape.rs
@@ -6,35 +6,38 @@ use std::io::BufWriter;
 use std::iter::FromIterator;
 
 fn main() {
-
-    let (doc, page1, layer1) = PdfDocument::new("printpdf graphics test", Mm(297.0), Mm(297.0), "Layer 1");
+    let (doc, page1, layer1) =
+        PdfDocument::new("printpdf graphics test", Mm(297.0), Mm(297.0), "Layer 1");
     let current_layer = doc.get_page(page1).get_layer(layer1);
 
     // Quadratic shape. The "false" determines if the next (following)
     // point is a bezier handle (for curves)
     // If you want holes, simply reorder the winding of the points to be
     // counterclockwise instead of clockwise.
-    let points1 = vec![(Point::new(Mm(100.0), Mm(100.0)), false),
-                       (Point::new(Mm(100.0), Mm(200.0)), false),
-                       (Point::new(Mm(300.0), Mm(200.0)), false),
-                       (Point::new(Mm(300.0), Mm(100.0)), false)];
+    let points1 = vec![
+        (Point::new(Mm(100.0), Mm(100.0)), false),
+        (Point::new(Mm(100.0), Mm(200.0)), false),
+        (Point::new(Mm(300.0), Mm(200.0)), false),
+        (Point::new(Mm(300.0), Mm(100.0)), false),
+    ];
 
     // Is the shape stroked? Is the shape closed? Is the shape filled?
-    let line1 = Line { 
-        points: points1, 
-        is_closed: true, 
+    let line1 = Line {
+        points: points1,
+        is_closed: true,
         has_fill: true,
         has_stroke: true,
         is_clipping_path: false,
     };
 
     // Triangle shape
-    // Note: Line is invisible by default, the previous method of 
+    // Note: Line is invisible by default, the previous method of
     // constructing a line is recommended!
     let mut line2 = Line::from_iter(vec![
         (Point::new(Mm(150.0), Mm(150.0)), false),
         (Point::new(Mm(150.0), Mm(250.0)), false),
-        (Point::new(Mm(350.0), Mm(250.0)), false)]);
+        (Point::new(Mm(350.0), Mm(250.0)), false),
+    ]);
 
     line2.set_closed(false);
     line2.set_stroke(true);
@@ -43,8 +46,10 @@ fn main() {
 
     let fill_color = Color::Cmyk(Cmyk::new(0.0, 0.23, 0.0, 0.0, None));
     let outline_color = Color::Rgb(Rgb::new(0.75, 1.0, 0.64, None));
-    let mut dash_pattern = LineDashPattern::default();
-    dash_pattern.dash_1 = Some(20);
+    let dash_pattern = LineDashPattern {
+        dash_1: Some(20),
+        ..Default::default()
+    };
 
     current_layer.set_fill_color(fill_color);
     current_layer.set_outline_color(outline_color);
@@ -70,5 +75,8 @@ fn main() {
 
     // If this is successful, you should see a PDF two shapes, one rectangle
     // and a dotted line
-    doc.save(&mut BufWriter::new(File::create("test_graphics.pdf").unwrap())).unwrap();
+    doc.save(&mut BufWriter::new(
+        File::create("test_graphics.pdf").unwrap(),
+    ))
+    .unwrap();
 }

--- a/examples/svg.rs
+++ b/examples/svg.rs
@@ -6,7 +6,8 @@ use printpdf::*;
 const SVG: &str = include_str!("../assets/svg/tiger.svg");
 
 fn main() {
-    let (doc, page1, layer1) = PdfDocument::new("printpdf graphics test", Mm(210.0), Mm(297.0), "Layer 1");
+    let (doc, page1, layer1) =
+        PdfDocument::new("printpdf graphics test", Mm(210.0), Mm(297.0), "Layer 1");
     let current_layer = doc.get_page(page1).get_layer(layer1);
     let svg = Svg::parse(SVG).unwrap();
 
@@ -16,18 +17,19 @@ fn main() {
     let reference = svg.into_xobject(&current_layer);
 
     for i in 0..10 {
-        reference
-        .clone()
-        .add_to_layer(&current_layer, SvgTransform {
-            rotate: Some(SvgRotation {
-                angle_ccw_degrees: i as f64 * 36.0,
-                rotation_center_x: rotation_center_x.into_pt(300.0),
-                rotation_center_y: rotation_center_y.into_pt(300.0),
-            }),
-            translate_x: Some(Mm(i as f64 * 20.0 % 50.0).into()),
-            translate_y: Some(Mm(i as f64 * 30.0).into()),
-            .. Default::default()
-        });
+        reference.clone().add_to_layer(
+            &current_layer,
+            SvgTransform {
+                rotate: Some(SvgRotation {
+                    angle_ccw_degrees: i as f64 * 36.0,
+                    rotation_center_x: rotation_center_x.into_pt(300.0),
+                    rotation_center_y: rotation_center_y.into_pt(300.0),
+                }),
+                translate_x: Some(Mm(i as f64 * 20.0 % 50.0).into()),
+                translate_y: Some(Mm(i as f64 * 30.0).into()),
+                ..Default::default()
+            },
+        );
     }
 
     let pdf_bytes = doc.save_to_bytes().unwrap();

--- a/src/color.rs
+++ b/src/color.rs
@@ -4,11 +4,12 @@
 use image_crate;
 use lopdf::content::Operation;
 
-use glob_defines::{
-    OP_COLOR_SET_FILL_CS_DEVICERGB, OP_COLOR_SET_FILL_CS_DEVICECMYK, OP_COLOR_SET_FILL_CS_DEVICEGRAY,
-    OP_COLOR_SET_STROKE_CS_DEVICERGB, OP_COLOR_SET_STROKE_CS_DEVICECMYK, OP_COLOR_SET_STROKE_CS_DEVICEGRAY,
+use crate::glob_defines::{
+    OP_COLOR_SET_FILL_CS_DEVICECMYK, OP_COLOR_SET_FILL_CS_DEVICEGRAY,
+    OP_COLOR_SET_FILL_CS_DEVICERGB, OP_COLOR_SET_STROKE_CS_DEVICECMYK,
+    OP_COLOR_SET_STROKE_CS_DEVICEGRAY, OP_COLOR_SET_STROKE_CS_DEVICERGB,
 };
-use IccProfileRef;
+use crate::IccProfileRef;
 
 /// Tuple for differentiating outline and fill colors
 #[derive(Debug, Clone, PartialEq)]
@@ -17,31 +18,28 @@ pub enum PdfColor {
     OutlineColor(Color),
 }
 
-impl Into<Operation> for PdfColor {
-
-    fn into(self)
-    -> Operation
-    {
+impl From<PdfColor> for Operation {
+    fn from(val: PdfColor) -> Self {
         use lopdf::Object::*;
 
         // todo: incorporate ICC profile instead of just setting the default device cmyk color space
         let (color_identifier, color_vec) = {
             use self::PdfColor::*;
-            match self {
+            match val {
                 FillColor(fill) => {
                     let ci = match fill {
-                        Color::Rgb(_) => { OP_COLOR_SET_FILL_CS_DEVICERGB }
-                        Color::Cmyk(_) | Color::SpotColor(_) => { OP_COLOR_SET_FILL_CS_DEVICECMYK }
-                        Color::Greyscale(_) => { OP_COLOR_SET_FILL_CS_DEVICEGRAY }
+                        Color::Rgb(_) => OP_COLOR_SET_FILL_CS_DEVICERGB,
+                        Color::Cmyk(_) | Color::SpotColor(_) => OP_COLOR_SET_FILL_CS_DEVICECMYK,
+                        Color::Greyscale(_) => OP_COLOR_SET_FILL_CS_DEVICEGRAY,
                     };
                     let cvec = fill.into_vec().into_iter().map(Real).collect();
                     (ci, cvec)
-                },
+                }
                 OutlineColor(outline) => {
                     let ci = match outline {
-                        Color::Rgb(_) => { OP_COLOR_SET_STROKE_CS_DEVICERGB }
-                        Color::Cmyk(_) | Color::SpotColor(_) => { OP_COLOR_SET_STROKE_CS_DEVICECMYK }
-                        Color::Greyscale(_) => { OP_COLOR_SET_STROKE_CS_DEVICEGRAY }
+                        Color::Rgb(_) => OP_COLOR_SET_STROKE_CS_DEVICERGB,
+                        Color::Cmyk(_) | Color::SpotColor(_) => OP_COLOR_SET_STROKE_CS_DEVICECMYK,
+                        Color::Greyscale(_) => OP_COLOR_SET_STROKE_CS_DEVICEGRAY,
                     };
 
                     let cvec = outline.into_vec().into_iter().map(Real).collect();
@@ -67,9 +65,7 @@ pub enum ColorSpace {
 
 #[cfg(feature = "embedded_images")]
 impl From<image_crate::ColorType> for ColorSpace {
-    fn from(color_type: image_crate::ColorType)
-    -> Self
-    {
+    fn from(color_type: image_crate::ColorType) -> Self {
         use image_crate::ColorType::*;
         match color_type {
             L8 | L16 => ColorSpace::Greyscale,
@@ -81,12 +77,10 @@ impl From<image_crate::ColorType> for ColorSpace {
     }
 }
 
-impl Into<&'static str> for ColorSpace {
-    fn into(self)
-    -> &'static str
-    {
+impl From<ColorSpace> for &'static str {
+    fn from(val: ColorSpace) -> Self {
         use self::ColorSpace::*;
-        match self {
+        match val {
             Rgb => "DeviceRGB",
             Cmyk => "DeviceCMYK",
             Greyscale => "DeviceGray",
@@ -106,9 +100,7 @@ pub enum ColorBits {
 
 #[cfg(feature = "embedded_images")]
 impl From<image_crate::ColorType> for ColorBits {
-    fn from(color_type: image_crate::ColorType)
-    -> ColorBits
-    {
+    fn from(color_type: image_crate::ColorType) -> ColorBits {
         use image_crate::ColorType::*;
         use ColorBits::*;
 
@@ -116,16 +108,13 @@ impl From<image_crate::ColorType> for ColorBits {
             L8 | La8 | Rgb8 | Rgba8 => Bit8,
             L16 | La16 | Rgb16 | Rgba16 => Bit16,
             _ => Bit8, // unreachable
-
         }
     }
 }
 
-impl Into<i64> for ColorBits {
-    fn into(self)
-    -> i64
-    {
-        match self {
+impl From<ColorBits> for i64 {
+    fn from(val: ColorBits) -> Self {
+        match val {
             ColorBits::Bit1 => 1,
             ColorBits::Bit8 => 8,
             ColorBits::Bit16 => 16,
@@ -139,27 +128,30 @@ pub enum Color {
     Rgb(Rgb),
     Cmyk(Cmyk),
     Greyscale(Greyscale),
-    SpotColor(SpotColor)
+    SpotColor(SpotColor),
 }
 
 impl Color {
-
     /// Consumes the color and converts into into a vector of numbers
-    pub fn into_vec(self)
-    -> Vec<f64>
-    {
+    pub fn into_vec(self) -> Vec<f64> {
         match self {
-            Color::Rgb(rgb) => { vec![rgb.r, rgb.g, rgb.b ]},
-            Color::Cmyk(cmyk) => { vec![cmyk.c, cmyk.m, cmyk.y, cmyk.k ]},
-            Color::Greyscale(gs) => { vec![gs.percent]},
-            Color::SpotColor(spot) => { vec![spot.c, spot.m, spot.y, spot.k ]},
+            Color::Rgb(rgb) => {
+                vec![rgb.r, rgb.g, rgb.b]
+            }
+            Color::Cmyk(cmyk) => {
+                vec![cmyk.c, cmyk.m, cmyk.y, cmyk.k]
+            }
+            Color::Greyscale(gs) => {
+                vec![gs.percent]
+            }
+            Color::SpotColor(spot) => {
+                vec![spot.c, spot.m, spot.y, spot.k]
+            }
         }
     }
 
     /// Returns if the color has an icc profile attached
-    pub fn get_icc_profile(&self)
-    -> Option<&Option<IccProfileRef>>
-    {
+    pub fn get_icc_profile(&self) -> Option<&Option<IccProfileRef>> {
         match *self {
             Color::Rgb(ref rgb) => Some(&rgb.icc_profile),
             Color::Cmyk(ref cmyk) => Some(&cmyk.icc_profile),
@@ -179,14 +171,15 @@ pub struct Rgb {
 }
 
 impl Rgb {
-
-    pub fn new(r: f64, g: f64, b: f64, icc_profile: Option<IccProfileRef>)
-    -> Self
-    {
-        Self { r, g, b, icc_profile }
+    pub fn new(r: f64, g: f64, b: f64, icc_profile: Option<IccProfileRef>) -> Self {
+        Self {
+            r,
+            g,
+            b,
+            icc_profile,
+        }
     }
 }
-
 
 /// CMYK color
 #[derive(Debug, Clone, PartialEq)]
@@ -200,10 +193,14 @@ pub struct Cmyk {
 
 impl Cmyk {
     /// Creates a new CMYK color
-    pub fn new(c: f64, m: f64, y: f64, k: f64, icc_profile: Option<IccProfileRef>)
-    -> Self
-    {
-        Self { c, m, y, k, icc_profile }
+    pub fn new(c: f64, m: f64, y: f64, k: f64, icc_profile: Option<IccProfileRef>) -> Self {
+        Self {
+            c,
+            m,
+            y,
+            k,
+            icc_profile,
+        }
     }
 }
 
@@ -215,13 +212,13 @@ pub struct Greyscale {
 }
 
 impl Greyscale {
-    pub fn new(percent: f64, icc_profile: Option<IccProfileRef>)
-    -> Self
-    {
-        Self { percent, icc_profile }
+    pub fn new(percent: f64, icc_profile: Option<IccProfileRef>) -> Self {
+        Self {
+            percent,
+            icc_profile,
+        }
     }
 }
-
 
 /// Spot color
 /// Spot colors are like Cmyk, but without color space
@@ -236,9 +233,7 @@ pub struct SpotColor {
 }
 
 impl SpotColor {
-    pub fn new(c: f64, m: f64, y: f64, k: f64)
-    -> Self
-    {
+    pub fn new(c: f64, m: f64, y: f64, k: f64) -> Self {
         Self { c, m, y, k }
     }
 }

--- a/src/document_info.rs
+++ b/src/document_info.rs
@@ -2,7 +2,7 @@
 
 use crate::OffsetDateTime;
 use lopdf;
-use PdfMetadata;
+use crate::PdfMetadata;
 /// "Info" dictionary of a PDF document.
 /// Actual data is contained in `DocumentMetadata`, to keep it in sync with the `XmpMetadata`
 /// (if the timestamps / settings are not in sync, Preflight will complain)
@@ -53,19 +53,14 @@ pub struct DocumentInfo {
 }
 
 impl DocumentInfo {
-
     /// Create a new doucment info dictionary from a document
-    pub fn new()
-    -> Self
-    {
+    pub fn new() -> Self {
         Self::default()
     }
 
     /// This functions is similar to the IntoPdfObject trait method,
     /// but takes additional arguments in order to delay the setting
-    pub(in crate) fn into_obj(self, m: &PdfMetadata)
-    -> lopdf::Object
-    {
+    pub(crate) fn into_obj(self, m: &PdfMetadata) -> lopdf::Object {
         use lopdf::Dictionary as LoDictionary;
         use lopdf::Object::*;
         use lopdf::StringFormat::Literal;
@@ -79,27 +74,38 @@ impl DocumentInfo {
 
         Dictionary(LoDictionary::from_iter(vec![
             ("Trapped", trapping.into()),
-            ("CreationDate", String(info_create_date.into_bytes(), Literal)),
+            (
+                "CreationDate",
+                String(info_create_date.into_bytes(), Literal),
+            ),
             ("ModDate", String(info_mod_date.into_bytes(), Literal)),
             ("GTS_PDFXVersion", String(gts_pdfx_version.into(), Literal)),
-            ("Title", String(m.document_title.to_string().as_bytes().to_vec(), Literal)),
+            (
+                "Title",
+                String(m.document_title.to_string().as_bytes().to_vec(), Literal),
+            ),
             ("Author", String(m.author.as_bytes().to_vec(), Literal)),
             ("Creator", String(m.creator.as_bytes().to_vec(), Literal)),
             ("Producer", String(m.producer.as_bytes().to_vec(), Literal)),
             ("Subject", String(m.subject.as_bytes().to_vec(), Literal)),
-            ("Identifier", String(m.identifier.as_bytes().to_vec(), Literal)),
-            ("Keywords", String(m.keywords.join(",").as_bytes().to_vec(), Literal))
+            (
+                "Identifier",
+                String(m.identifier.as_bytes().to_vec(), Literal),
+            ),
+            (
+                "Keywords",
+                String(m.keywords.join(",").as_bytes().to_vec(), Literal),
+            ),
         ]))
     }
 }
 
 // D:20170505150224+02'00'
-fn to_pdf_time_stamp_metadata(date: &OffsetDateTime)
--> String
-{
+fn to_pdf_time_stamp_metadata(date: &OffsetDateTime) -> String {
     // Since the time is in UTC, we know that the time zone
     // difference to UTC is 0 min, 0 sec, hence the 00'00
-    format!("D:{:04}{:02}{:02}{:02}{:02}{:02}+00'00'",
+    format!(
+        "D:{:04}{:02}{:02}{:02}{:02}{:02}+00'00'",
         date.year(),
         date.month(),
         date.day(),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,9 +1,9 @@
 //! Errors for printpdf
 
-use std::error::Error as IError;
-use std::io::Error as IoError;
 use owned_ttf_parser::FaceParsingError;
+use std::error::Error as IError;
 use std::fmt;
+use std::io::Error as IoError;
 
 /// error_chain and failure are certainly nice, but completely overengineered
 /// for this use-case. For example, neither of them allow error localization.
@@ -15,13 +15,13 @@ use std::fmt;
 ///
 /// What this macro does is (simplified): `impl From<$a> for $b { $b::$variant(error) }`
 macro_rules! impl_from {
-    ($from:ident, $to:ident::$variant:ident) => (
+    ($from:ident, $to:ident::$variant:ident) => {
         impl From<$from> for $to {
             fn from(err: $from) -> Self {
                 $to::$variant(err.into())
             }
         }
-    )
+    };
 }
 
 #[derive(Debug)]
@@ -59,11 +59,15 @@ pub enum IndexError {
 impl fmt::Display for IndexError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::IndexError::*;
-        write!(f, "{}", match *self {
-            PdfPageIndexError => "Page index out of bounds",
-            PdfLayerIndexError => "PDF layer index out of bounds",
-            PdfMarkerIndexError => "PDF layer index out of bounds",
-        })
+        write!(
+            f,
+            "{}",
+            match *self {
+                PdfPageIndexError => "Page index out of bounds",
+                PdfLayerIndexError => "PDF layer index out of bounds",
+                PdfMarkerIndexError => "PDF layer index out of bounds",
+            }
+        )
     }
 }
 
@@ -77,11 +81,11 @@ impl_from!(IndexError, Error::Index);
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use self::Error::*;
-        match *self {
-            Io(ref e) => write!(f, "{}", e),
-            FaceParsing(ref e) => write!(f, "{}", e),
-            Pdf(ref e) => write!(f, "{}", e),
-            Index(ref e) => write!(f, "{}", e),
+        match self {
+            Io(e) => write!(f, "{e}"),
+            FaceParsing(e) => write!(f, "{e}"),
+            Pdf(e) => write!(f, "{e}"),
+            Index(e) => write!(f, "{e}"),
         }
     }
 }

--- a/src/extgstate.rs
+++ b/src/extgstate.rs
@@ -34,44 +34,44 @@
 //! }
 //! ```
 
+use crate::indices::FontIndex;
 use lopdf;
 use lopdf::content::Operation;
 use lopdf::Object::*;
-use std::string::String;
-use indices::FontIndex;
-use std::collections::HashSet;
 use std::collections::HashMap;
+use std::collections::HashSet;
+use std::string::String;
 
 // identifiers for tracking the changed fields
-pub (crate) const LINE_WIDTH: &'static str = "line_width";
-pub (crate) const LINE_CAP: &'static str = "line_cap";
-pub (crate) const LINE_JOIN: &'static str = "line_join";
-pub (crate) const MITER_LIMIT: &'static str = "miter_limit";
-pub (crate) const LINE_DASH_PATTERN: &'static str = "line_dash_pattern";
-pub (crate) const RENDERING_INTENT: &'static str = "rendering_intent";
-pub (crate) const OVERPRINT_STROKE: &'static str = "overprint_stroke";
-pub (crate) const OVERPRINT_FILL: &'static str = "overprint_fill";
-pub (crate) const OVERPRINT_MODE: &'static str = "overprint_mode";
-pub (crate) const FONT: &'static str = "font";
-pub (crate) const BLACK_GENERATION: &'static str = "black_generation";
-pub (crate) const BLACK_GENERATION_EXTRA: &'static str = "black_generation_extra";
-pub (crate) const UNDERCOLOR_REMOVAL: &'static str = "under_color_removal";
-pub (crate) const UNDERCOLOR_REMOVAL_EXTRA: &'static str = "undercolor_removal_extra";
-pub (crate) const TRANSFER_FUNCTION: &'static str = "transfer_function";
-pub (crate) const TRANSFER_FUNCTION_EXTRA: &'static str = "transfer_function_extra";
-pub (crate) const HALFTONE_DICTIONARY: &'static str = "halftone_dictionary";
-pub (crate) const FLATNESS_TOLERANCE: &'static str = "flatness_tolerance";
-pub (crate) const SMOOTHNESS_TOLERANCE: &'static str = "smoothness_tolerance";
-pub (crate) const STROKE_ADJUSTMENT: &'static str = "stroke_adjustment";
-pub (crate) const BLEND_MODE: &'static str = "blend_mode";
-pub (crate) const SOFT_MASK: &'static str = "soft_mask";
-pub (crate) const CURRENT_STROKE_ALPHA: &'static str = "current_stroke_alpha";
-pub (crate) const CURRENT_FILL_ALPHA: &'static str = "current_fill_alpha";
-pub (crate) const ALPHA_IS_SHAPE: &'static str = "alpha_is_shape";
-pub (crate) const TEXT_KNOCKOUT: &'static str = "text_knockout";
+pub(crate) const LINE_WIDTH: &str = "line_width";
+pub(crate) const LINE_CAP: &str = "line_cap";
+pub(crate) const LINE_JOIN: &str = "line_join";
+pub(crate) const MITER_LIMIT: &str = "miter_limit";
+pub(crate) const LINE_DASH_PATTERN: &str = "line_dash_pattern";
+pub(crate) const RENDERING_INTENT: &str = "rendering_intent";
+pub(crate) const OVERPRINT_STROKE: &str = "overprint_stroke";
+pub(crate) const OVERPRINT_FILL: &str = "overprint_fill";
+pub(crate) const OVERPRINT_MODE: &str = "overprint_mode";
+pub(crate) const FONT: &str = "font";
+pub(crate) const BLACK_GENERATION: &str = "black_generation";
+pub(crate) const BLACK_GENERATION_EXTRA: &str = "black_generation_extra";
+pub(crate) const UNDERCOLOR_REMOVAL: &str = "under_color_removal";
+pub(crate) const UNDERCOLOR_REMOVAL_EXTRA: &str = "undercolor_removal_extra";
+pub(crate) const TRANSFER_FUNCTION: &str = "transfer_function";
+pub(crate) const TRANSFER_FUNCTION_EXTRA: &str = "transfer_function_extra";
+pub(crate) const HALFTONE_DICTIONARY: &str = "halftone_dictionary";
+pub(crate) const FLATNESS_TOLERANCE: &str = "flatness_tolerance";
+pub(crate) const SMOOTHNESS_TOLERANCE: &str = "smoothness_tolerance";
+pub(crate) const STROKE_ADJUSTMENT: &str = "stroke_adjustment";
+pub(crate) const BLEND_MODE: &str = "blend_mode";
+pub(crate) const SOFT_MASK: &str = "soft_mask";
+pub(crate) const CURRENT_STROKE_ALPHA: &str = "current_stroke_alpha";
+pub(crate) const CURRENT_FILL_ALPHA: &str = "current_fill_alpha";
+pub(crate) const ALPHA_IS_SHAPE: &str = "alpha_is_shape";
+pub(crate) const TEXT_KNOCKOUT: &str = "text_knockout";
 
 /// List of many `ExtendedGraphicsState`
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ExtendedGraphicsStateList {
     /// Current indent level + current graphics state
     pub(crate) latest_graphics_state: (usize, ExtendedGraphicsState),
@@ -80,50 +80,37 @@ pub struct ExtendedGraphicsStateList {
     pub(crate) all_graphics_states: HashMap<String, (usize, ExtendedGraphicsState)>,
 }
 
-impl Default for ExtendedGraphicsStateList {
-    fn default()
-    -> Self
-    {
-        Self {
-            latest_graphics_state: (0, ExtendedGraphicsState::default()),
-            all_graphics_states: HashMap::new(),
-        }
-    }
-}
-
 impl ExtendedGraphicsStateList {
     /// Creates a new ExtendedGraphicsStateList
-    pub fn new()
-    -> Self
-    {
+    pub fn new() -> Self {
         Self::default()
     }
 
     /// Adds a graphics state
-    pub fn add_graphics_state(&mut self, added_state: ExtendedGraphicsState)
-    -> ExtendedGraphicsStateRef
-    {
+    pub fn add_graphics_state(
+        &mut self,
+        added_state: ExtendedGraphicsState,
+    ) -> ExtendedGraphicsStateRef {
         let gs_ref = ExtendedGraphicsStateRef::new(self.all_graphics_states.len());
-        self.all_graphics_states.insert(gs_ref.gs_name.clone(), (self.latest_graphics_state.0, added_state.clone()));
+        self.all_graphics_states.insert(
+            gs_ref.gs_name.clone(),
+            (self.latest_graphics_state.0, added_state.clone()),
+        );
         self.latest_graphics_state = (self.latest_graphics_state.0, added_state);
         gs_ref
     }
 }
 
-impl Into<lopdf::Dictionary> for ExtendedGraphicsStateList {
-
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_return))]
-    fn into(self)
-    -> lopdf::Dictionary
-    {
+impl From<ExtendedGraphicsStateList> for lopdf::Dictionary {
+    fn from(val: ExtendedGraphicsStateList) -> Self {
         let mut ext_g_state_resources = lopdf::Dictionary::new();
 
-        for (name, (_, graphics_state)) in self.all_graphics_states {
+        for (name, (_, graphics_state)) in val.all_graphics_states {
             let gs: lopdf::Object = graphics_state.into();
             ext_g_state_resources.set(name.to_string(), gs);
         }
 
-        return ext_g_state_resources;
+        ext_g_state_resources
     }
 }
 
@@ -131,7 +118,6 @@ impl Into<lopdf::Dictionary> for ExtendedGraphicsStateList {
 #[derive(Debug, PartialEq, Clone)]
 pub struct ExtendedGraphicsState {
     /* /Type ExtGState */
-
     /// NOTE: We need to track which fields have changed in relation to the default() method.
     /// This is because we want to optimize out the fields that haven't changed in relation
     /// to the last graphics state. Please use only the constants defined in this module for
@@ -309,19 +295,14 @@ pub struct ExtendedGraphicsStateBuilder {
 }
 
 impl ExtendedGraphicsStateBuilder {
-
     /// Creates a new graphics state builder
-    pub fn new()
-    -> Self
-    {
+    pub fn new() -> Self {
         Self::default()
     }
 
     /// Sets the line width
     #[inline]
-    pub fn with_line_width(mut self, line_width: f64)
-    -> Self
-    {
+    pub fn with_line_width(mut self, line_width: f64) -> Self {
         self.gs.line_width = line_width;
         self.gs.changed_fields.insert(LINE_WIDTH);
         self
@@ -329,9 +310,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the line cap
     #[inline]
-    pub fn with_line_cap(mut self, line_cap: LineCapStyle)
-    -> Self
-    {
+    pub fn with_line_cap(mut self, line_cap: LineCapStyle) -> Self {
         self.gs.line_cap = line_cap;
         self.gs.changed_fields.insert(LINE_CAP);
         self
@@ -339,9 +318,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the line join
     #[inline]
-    pub fn with_line_join(mut self, line_join: LineJoinStyle)
-    -> Self
-    {
+    pub fn with_line_join(mut self, line_join: LineJoinStyle) -> Self {
         self.gs.line_join = line_join;
         self.gs.changed_fields.insert(LINE_JOIN);
         self
@@ -349,9 +326,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the miter limit
     #[inline]
-    pub fn with_miter_limit(mut self, miter_limit: f64)
-    -> Self
-    {
+    pub fn with_miter_limit(mut self, miter_limit: f64) -> Self {
         self.gs.miter_limit = miter_limit;
         self.gs.changed_fields.insert(MITER_LIMIT);
         self
@@ -359,9 +334,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the rendering intent
     #[inline]
-    pub fn with_rendering_intent(mut self, rendering_intent: RenderingIntent)
-    -> Self
-    {
+    pub fn with_rendering_intent(mut self, rendering_intent: RenderingIntent) -> Self {
         self.gs.rendering_intent = rendering_intent;
         self.gs.changed_fields.insert(RENDERING_INTENT);
         self
@@ -369,9 +342,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the stroke overprint
     #[inline]
-    pub fn with_overprint_stroke(mut self, overprint_stroke: bool)
-    -> Self
-    {
+    pub fn with_overprint_stroke(mut self, overprint_stroke: bool) -> Self {
         self.gs.overprint_stroke = overprint_stroke;
         self.gs.changed_fields.insert(OVERPRINT_STROKE);
         self
@@ -379,9 +350,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the fill overprint
     #[inline]
-    pub fn with_overprint_fill(mut self, overprint_fill: bool)
-    -> Self
-    {
+    pub fn with_overprint_fill(mut self, overprint_fill: bool) -> Self {
         self.gs.overprint_fill = overprint_fill;
         self.gs.changed_fields.insert(OVERPRINT_FILL);
         self
@@ -389,9 +358,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the overprint mode
     #[inline]
-    pub fn with_overprint_mode(mut self, overprint_mode: OverprintMode)
-    -> Self
-    {
+    pub fn with_overprint_mode(mut self, overprint_mode: OverprintMode) -> Self {
         self.gs.overprint_mode = overprint_mode;
         self.gs.changed_fields.insert(OVERPRINT_MODE);
         self
@@ -400,9 +367,7 @@ impl ExtendedGraphicsStateBuilder {
     /// Sets the font
     /// __WARNING:__ Use `layer.add_font()` instead if you are not absolutely sure.
     #[inline]
-    pub fn with_font(mut self, font: Option<FontIndex>)
-    -> Self
-    {
+    pub fn with_font(mut self, font: Option<FontIndex>) -> Self {
         self.gs.font = font;
         self.gs.changed_fields.insert(FONT);
         self
@@ -410,9 +375,10 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the black generation
     #[inline]
-    pub fn with_black_generation(mut self, black_generation: Option<BlackGenerationFunction>)
-    -> Self
-    {
+    pub fn with_black_generation(
+        mut self,
+        black_generation: Option<BlackGenerationFunction>,
+    ) -> Self {
         self.gs.black_generation = black_generation;
         self.gs.changed_fields.insert(BLACK_GENERATION);
         self
@@ -420,9 +386,10 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the black generation extra function
     #[inline]
-    pub fn with_black_generation_extra(mut self, black_generation_extra: Option<BlackGenerationExtraFunction>)
-    -> Self
-    {
+    pub fn with_black_generation_extra(
+        mut self,
+        black_generation_extra: Option<BlackGenerationExtraFunction>,
+    ) -> Self {
         self.gs.black_generation_extra = black_generation_extra;
         self.gs.changed_fields.insert(BLACK_GENERATION_EXTRA);
         self
@@ -430,9 +397,10 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the undercolor removal function
     #[inline]
-    pub fn with_undercolor_removal(mut self, under_color_removal: Option<UnderColorRemovalFunction>)
-    -> Self
-    {
+    pub fn with_undercolor_removal(
+        mut self,
+        under_color_removal: Option<UnderColorRemovalFunction>,
+    ) -> Self {
         self.gs.under_color_removal = under_color_removal;
         self.gs.changed_fields.insert(UNDERCOLOR_REMOVAL);
         self
@@ -440,9 +408,10 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the undercolor removal extra function
     #[inline]
-    pub fn with_undercolor_removal_extra(mut self, under_color_removal_extra: Option<UnderColorRemovalExtraFunction>)
-    -> Self
-    {
+    pub fn with_undercolor_removal_extra(
+        mut self,
+        under_color_removal_extra: Option<UnderColorRemovalExtraFunction>,
+    ) -> Self {
         self.gs.under_color_removal_extra = under_color_removal_extra;
         self.gs.changed_fields.insert(UNDERCOLOR_REMOVAL_EXTRA);
         self
@@ -450,9 +419,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the transfer function
     #[inline]
-    pub fn with_transfer(mut self, transfer_function: Option<TransferFunction>)
-    -> Self
-    {
+    pub fn with_transfer(mut self, transfer_function: Option<TransferFunction>) -> Self {
         self.gs.transfer_function = transfer_function;
         self.gs.changed_fields.insert(TRANSFER_FUNCTION);
         self
@@ -460,9 +427,10 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the transfer extra function
     #[inline]
-    pub fn with_transfer_extra(mut self, transfer_extra_function: Option<TransferExtraFunction>)
-    -> Self
-    {
+    pub fn with_transfer_extra(
+        mut self,
+        transfer_extra_function: Option<TransferExtraFunction>,
+    ) -> Self {
         self.gs.transfer_extra_function = transfer_extra_function;
         self.gs.changed_fields.insert(TRANSFER_FUNCTION_EXTRA);
         self
@@ -470,9 +438,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the halftone dictionary
     #[inline]
-    pub fn with_halftone(mut self, halftone_type: Option<HalftoneType>)
-    -> Self
-    {
+    pub fn with_halftone(mut self, halftone_type: Option<HalftoneType>) -> Self {
         self.gs.halftone_dictionary = halftone_type;
         self.gs.changed_fields.insert(HALFTONE_DICTIONARY);
         self
@@ -480,9 +446,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the flatness tolerance
     #[inline]
-    pub fn with_flatness_tolerance(mut self, flatness_tolerance: f64)
-    -> Self
-    {
+    pub fn with_flatness_tolerance(mut self, flatness_tolerance: f64) -> Self {
         self.gs.flatness_tolerance = flatness_tolerance;
         self.gs.changed_fields.insert(FLATNESS_TOLERANCE);
         self
@@ -490,9 +454,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the smoothness tolerance
     #[inline]
-    pub fn with_smoothness_tolerance(mut self, smoothness_tolerance: f64)
-    -> Self
-    {
+    pub fn with_smoothness_tolerance(mut self, smoothness_tolerance: f64) -> Self {
         self.gs.smoothness_tolerance = smoothness_tolerance;
         self.gs.changed_fields.insert(SMOOTHNESS_TOLERANCE);
         self
@@ -500,9 +462,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the stroke adjustment
     #[inline]
-    pub fn with_stroke_adjustment(mut self, stroke_adjustment: bool)
-    -> Self
-    {
+    pub fn with_stroke_adjustment(mut self, stroke_adjustment: bool) -> Self {
         self.gs.stroke_adjustment = stroke_adjustment;
         self.gs.changed_fields.insert(STROKE_ADJUSTMENT);
         self
@@ -510,9 +470,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the blend mode
     #[inline]
-    pub fn with_blend_mode(mut self, blend_mode: BlendMode)
-    -> Self
-    {
+    pub fn with_blend_mode(mut self, blend_mode: BlendMode) -> Self {
         self.gs.blend_mode = blend_mode;
         self.gs.changed_fields.insert(BLEND_MODE);
         self
@@ -520,9 +478,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the soft mask
     #[inline]
-    pub fn with_soft_mask(mut self, soft_mask: Option<SoftMask>)
-    -> Self
-    {
+    pub fn with_soft_mask(mut self, soft_mask: Option<SoftMask>) -> Self {
         self.gs.soft_mask = soft_mask;
         self.gs.changed_fields.insert(SOFT_MASK);
         self
@@ -530,9 +486,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the current alpha for strokes
     #[inline]
-    pub fn with_current_stroke_alpha(mut self, current_stroke_alpha: f64)
-    -> Self
-    {
+    pub fn with_current_stroke_alpha(mut self, current_stroke_alpha: f64) -> Self {
         self.gs.current_stroke_alpha = current_stroke_alpha;
         self.gs.changed_fields.insert(CURRENT_STROKE_ALPHA);
         self
@@ -540,9 +494,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the current alpha for fills
     #[inline]
-    pub fn with_current_fill_alpha(mut self, current_fill_alpha: f64)
-    -> Self
-    {
+    pub fn with_current_fill_alpha(mut self, current_fill_alpha: f64) -> Self {
         self.gs.current_fill_alpha = current_fill_alpha;
         self.gs.changed_fields.insert(CURRENT_FILL_ALPHA);
         self
@@ -550,9 +502,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the current "alpha is shape"
     #[inline]
-    pub fn with_alpha_is_shape(mut self, alpha_is_shape: bool)
-    -> Self
-    {
+    pub fn with_alpha_is_shape(mut self, alpha_is_shape: bool) -> Self {
         self.gs.alpha_is_shape = alpha_is_shape;
         self.gs.changed_fields.insert(ALPHA_IS_SHAPE);
         self
@@ -560,9 +510,7 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Sets the current text knockout
     #[inline]
-    pub fn with_text_knockout(mut self, text_knockout: bool)
-    -> Self
-    {
+    pub fn with_text_knockout(mut self, text_knockout: bool) -> Self {
         self.gs.text_knockout = text_knockout;
         self.gs.changed_fields.insert(TEXT_KNOCKOUT);
         self
@@ -570,19 +518,15 @@ impl ExtendedGraphicsStateBuilder {
 
     /// Consumes the builder and returns an actual ExtendedGraphicsState
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_return))]
-    pub fn build(self)
-    -> ExtendedGraphicsState
-    {
-        return self.gs;
+
+    pub fn build(self) -> ExtendedGraphicsState {
+        self.gs
     }
 }
 
 impl Default for ExtendedGraphicsState {
     /// Creates a default ExtGState dictionary. Useful for resetting
-    fn default()
-    -> Self
-    {
+    fn default() -> Self {
         Self {
             changed_fields: HashSet::new(),
             line_width: 1.0,
@@ -615,91 +559,86 @@ impl Default for ExtendedGraphicsState {
     }
 }
 
-impl Into<lopdf::Object> for ExtendedGraphicsState {
-
+impl From<ExtendedGraphicsState> for lopdf::Object {
     /// Compares the current graphics state with the previous one and returns an
     /// "optimized" graphics state, meaning only the fields that have changed in
     /// comparison to the previous one are returned.
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_return))]
-    #[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
-    #[cfg_attr(feature = "cargo-clippy", allow(string_lit_as_bytes))]
-    fn into(self)
-    -> lopdf::Object
-    {
+
+    fn from(val: ExtendedGraphicsState) -> Self {
         use std::iter::FromIterator;
         let mut gs_operations = Vec::<(String, lopdf::Object)>::new();
 
         // for each field, look if it was contained in the "changed fields"
-        if self.changed_fields.contains(LINE_WIDTH) {
-            gs_operations.push(("LW".to_string(), self.line_width.into()));
+        if val.changed_fields.contains(LINE_WIDTH) {
+            gs_operations.push(("LW".to_string(), val.line_width.into()));
         }
 
-        if self.changed_fields.contains(LINE_CAP) {
-            gs_operations.push(("LC".to_string(), self.line_cap.into()));
+        if val.changed_fields.contains(LINE_CAP) {
+            gs_operations.push(("LC".to_string(), val.line_cap.into()));
         }
 
-        if self.changed_fields.contains(LINE_JOIN) {
-            gs_operations.push(("LJ".to_string(), self.line_join.into()));
+        if val.changed_fields.contains(LINE_JOIN) {
+            gs_operations.push(("LJ".to_string(), val.line_join.into()));
         }
 
-        if self.changed_fields.contains(MITER_LIMIT) {
-            gs_operations.push(("ML".to_string(), self.miter_limit.into()));
+        if val.changed_fields.contains(MITER_LIMIT) {
+            gs_operations.push(("ML".to_string(), val.miter_limit.into()));
         }
 
-        if self.changed_fields.contains(FLATNESS_TOLERANCE) {
-            gs_operations.push(("FL".to_string(), self.flatness_tolerance.into()));
+        if val.changed_fields.contains(FLATNESS_TOLERANCE) {
+            gs_operations.push(("FL".to_string(), val.flatness_tolerance.into()));
         }
 
-        if self.changed_fields.contains(RENDERING_INTENT) {
-            gs_operations.push(("RI".to_string(), self.rendering_intent.into()));
+        if val.changed_fields.contains(RENDERING_INTENT) {
+            gs_operations.push(("RI".to_string(), val.rendering_intent.into()));
         }
 
-        if self.changed_fields.contains(STROKE_ADJUSTMENT) {
-            gs_operations.push(("SA".to_string(), self.stroke_adjustment.into()));
+        if val.changed_fields.contains(STROKE_ADJUSTMENT) {
+            gs_operations.push(("SA".to_string(), val.stroke_adjustment.into()));
         }
 
-        if self.changed_fields.contains(OVERPRINT_FILL) {
-            gs_operations.push(("OP".to_string(), self.overprint_fill.into()));
+        if val.changed_fields.contains(OVERPRINT_FILL) {
+            gs_operations.push(("OP".to_string(), val.overprint_fill.into()));
         }
 
-        if self.changed_fields.contains(OVERPRINT_STROKE) {
-            gs_operations.push(("op".to_string(), self.overprint_stroke.into()));
+        if val.changed_fields.contains(OVERPRINT_STROKE) {
+            gs_operations.push(("op".to_string(), val.overprint_stroke.into()));
         }
 
-        if self.changed_fields.contains(OVERPRINT_MODE) {
-            gs_operations.push(("OPM".to_string(), self.overprint_mode.into()));
+        if val.changed_fields.contains(OVERPRINT_MODE) {
+            gs_operations.push(("OPM".to_string(), val.overprint_mode.into()));
         }
 
-        if self.changed_fields.contains(CURRENT_FILL_ALPHA) {
-            gs_operations.push(("CA".to_string(), self.current_fill_alpha.into()));
+        if val.changed_fields.contains(CURRENT_FILL_ALPHA) {
+            gs_operations.push(("CA".to_string(), val.current_fill_alpha.into()));
         }
 
-        if self.changed_fields.contains(CURRENT_STROKE_ALPHA) {
-            gs_operations.push(("ca".to_string(), self.current_stroke_alpha.into()));
+        if val.changed_fields.contains(CURRENT_STROKE_ALPHA) {
+            gs_operations.push(("ca".to_string(), val.current_stroke_alpha.into()));
         }
 
-        if self.changed_fields.contains(BLEND_MODE) {
-            gs_operations.push(("BM".to_string(), self.blend_mode.into()));
+        if val.changed_fields.contains(BLEND_MODE) {
+            gs_operations.push(("BM".to_string(), val.blend_mode.into()));
         }
 
-        if self.changed_fields.contains(ALPHA_IS_SHAPE) {
-            gs_operations.push(("AIS".to_string(), self.alpha_is_shape.into()));
+        if val.changed_fields.contains(ALPHA_IS_SHAPE) {
+            gs_operations.push(("AIS".to_string(), val.alpha_is_shape.into()));
         }
 
-        if self.changed_fields.contains(TEXT_KNOCKOUT) {
-            gs_operations.push(("TK".to_string(), self.text_knockout.into()));
+        if val.changed_fields.contains(TEXT_KNOCKOUT) {
+            gs_operations.push(("TK".to_string(), val.text_knockout.into()));
         }
 
         // set optional parameters
-        if let Some(ldp) = self.line_dash_pattern {
-            if self.changed_fields.contains(LINE_DASH_PATTERN) {
+        if let Some(ldp) = val.line_dash_pattern {
+            if val.changed_fields.contains(LINE_DASH_PATTERN) {
                 let pattern: lopdf::Object = ldp.into();
                 gs_operations.push(("D".to_string(), pattern));
             }
         }
 
-        if let Some(ref font) = self.font {
-            if self.changed_fields.contains(FONT) {
+        if let Some(ref font) = val.font {
+            if val.changed_fields.contains(FONT) {
                 // let font_ref: lopdf::Object = font.into(); /* should be a reference to a font dictionary later on*/
                 // gs_operations.push(("Font".to_string(), font_ref));
             }
@@ -710,51 +649,36 @@ impl Into<lopdf::Object> for ExtendedGraphicsState {
         // these types cannot yet be converted into lopdf::Objects,
         // need to implement Into<Object> for them
 
-        if self.changed_fields.contains(BLACK_GENERATION) {
-            if let Some(ref black_generation) = self.black_generation {
-
-            }
+        if val.changed_fields.contains(BLACK_GENERATION) {
+            if let Some(ref black_generation) = val.black_generation {}
         }
 
-        if self.changed_fields.contains(BLACK_GENERATION_EXTRA) {
-            if let Some(ref black_generation_extra) = self.black_generation_extra {
-
-            }
+        if val.changed_fields.contains(BLACK_GENERATION_EXTRA) {
+            if let Some(ref black_generation_extra) = val.black_generation_extra {}
         }
 
-        if self.changed_fields.contains(UNDERCOLOR_REMOVAL) {
-            if let Some(ref under_color_removal) = self.under_color_removal {
-
-            }
+        if val.changed_fields.contains(UNDERCOLOR_REMOVAL) {
+            if let Some(ref under_color_removal) = val.under_color_removal {}
         }
 
-        if self.changed_fields.contains(UNDERCOLOR_REMOVAL_EXTRA) {
-            if let Some(ref under_color_removal_extra) = self.under_color_removal_extra {
-
-           }
+        if val.changed_fields.contains(UNDERCOLOR_REMOVAL_EXTRA) {
+            if let Some(ref under_color_removal_extra) = val.under_color_removal_extra {}
         }
 
-        if self.changed_fields.contains(TRANSFER_FUNCTION) {
-            if let Some(ref transfer_function) = self.transfer_function {
-
-            }
+        if val.changed_fields.contains(TRANSFER_FUNCTION) {
+            if let Some(ref transfer_function) = val.transfer_function {}
         }
 
-        if self.changed_fields.contains(TRANSFER_FUNCTION_EXTRA) {
-            if let Some(ref transfer_extra_function) = self.transfer_extra_function {
-
-            }
+        if val.changed_fields.contains(TRANSFER_FUNCTION_EXTRA) {
+            if let Some(ref transfer_extra_function) = val.transfer_extra_function {}
         }
 
-        if self.changed_fields.contains(HALFTONE_DICTIONARY) {
-            if let Some(ref halftone_dictionary) = self.halftone_dictionary {
-
-            }
+        if val.changed_fields.contains(HALFTONE_DICTIONARY) {
+            if let Some(ref halftone_dictionary) = val.halftone_dictionary {}
         }
 
-        if self.changed_fields.contains(SOFT_MASK) {
-            if let Some(ref soft_mask) = self.soft_mask {
-
+        if val.changed_fields.contains(SOFT_MASK) {
+            if let Some(ref soft_mask) = val.soft_mask {
             } else {
                 gs_operations.push(("SM".to_string(), Name("None".as_bytes().to_vec())));
             }
@@ -768,7 +692,7 @@ impl Into<lopdf::Object> for ExtendedGraphicsState {
 
         let graphics_state = lopdf::Dictionary::from_iter(gs_operations);
 
-        return Dictionary(graphics_state);
+        Dictionary(graphics_state)
     }
 }
 
@@ -782,11 +706,9 @@ pub struct ExtendedGraphicsStateRef {
 impl ExtendedGraphicsStateRef {
     /// Creates a new graphics state reference (in order to be unique inside a page)
     #[inline]
-    pub fn new(index: usize)
-    -> Self
-    {
+    pub fn new(index: usize) -> Self {
         Self {
-            gs_name: format!("GS{:?}", index)
+            gs_name: format!("GS{index:?}"),
         }
     }
 }
@@ -800,17 +722,15 @@ pub enum OverprintMode {
     /// Erase underlying color when overprinting
     EraseUnderlying, /* 0, default */
     /// Keep underlying color when overprinting
-    KeepUnderlying,  /* 1 */
+    KeepUnderlying, /* 1 */
 }
 
-impl Into<lopdf::Object> for OverprintMode {
-    fn into(self)
-    -> lopdf::Object
-    {
+impl From<OverprintMode> for lopdf::Object {
+    fn from(val: OverprintMode) -> Self {
         use self::OverprintMode::*;
-        match self {
-            EraseUnderlying     => Integer(0),
-            KeepUnderlying      => Integer(1),
+        match val {
+            EraseUnderlying => Integer(0),
+            KeepUnderlying => Integer(1),
         }
     }
 }
@@ -841,9 +761,7 @@ pub enum BlackGenerationFunction {
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub enum BlackGenerationExtraFunction {
-
-}
+pub enum BlackGenerationExtraFunction {}
 
 /// See `BlackGenerationFunction`, too. Undercolor removal reduces the amounts
 /// of the cyan, magenta, and yellow components to compensate for the amount of
@@ -860,19 +778,13 @@ pub enum UnderColorRemovalFunction {
 }
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub enum UnderColorRemovalExtraFunction {
-
-}
+pub enum UnderColorRemovalExtraFunction {}
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub enum TransferFunction {
-
-}
+pub enum TransferFunction {}
 
 #[derive(Debug, PartialEq, Copy, Clone)]
-pub enum TransferExtraFunction {
-
-}
+pub enum TransferExtraFunction {}
 
 /// In PDF 1.2, the graphics state includes a current halftone parameter,
 /// which determines the halftoning process to be used by the painting operators.
@@ -917,9 +829,7 @@ pub enum HalftoneType {
 
 impl HalftoneType {
     /// Get the identifer integer of the HalftoneType
-    pub fn get_type(&self)
-    -> i64
-    {
+    pub fn get_type(&self) -> i64 {
         use self::HalftoneType::*;
         match *self {
             Type1(_, _, _) => 1,
@@ -930,14 +840,12 @@ impl HalftoneType {
         }
     }
 
-    pub fn into_obj(self)
-    -> Vec<lopdf::Object>
-    {
+    pub fn into_obj(self) -> Vec<lopdf::Object> {
         use std::iter::FromIterator;
         vec![Dictionary(lopdf::Dictionary::from_iter(vec![
-                    ("Type", "Halftone".into()),
-                    ("HalftoneType", self.get_type().into())
-            ]))]
+            ("Type", "Halftone".into()),
+            ("HalftoneType", self.get_type().into()),
+        ]))]
     }
 }
 
@@ -1020,38 +928,33 @@ pub enum BlendMode {
     NonSeperable(NonSeperableBlendMode),
 }
 
-impl Into<lopdf::Object> for BlendMode {
-    fn into(self)
-    -> lopdf::Object {
+impl From<BlendMode> for lopdf::Object {
+    fn from(val: BlendMode) -> Self {
         use self::BlendMode::*;
-        use self::SeperableBlendMode::*;
         use self::NonSeperableBlendMode::*;
+        use self::SeperableBlendMode::*;
 
-        let blend_mode_str = match self {
-            Seperable(s) => {
-                match s {
-                    Normal => "Normal",
-                    Multiply => "Multiply",
-                    Screen => "Screen",
-                    Overlay => "Overlay",
-                    Darken => "Darken",
-                    Lighten => "Lighten",
-                    ColorDodge => "ColorDodge",
-                    ColorBurn => "ColorBurn",
-                    HardLight => "HardLight",
-                    SoftLight => "SoftLight",
-                    Difference => "Difference",
-                    Exclusion => "Exclusion",
-                }
+        let blend_mode_str = match val {
+            Seperable(s) => match s {
+                Normal => "Normal",
+                Multiply => "Multiply",
+                Screen => "Screen",
+                Overlay => "Overlay",
+                Darken => "Darken",
+                Lighten => "Lighten",
+                ColorDodge => "ColorDodge",
+                ColorBurn => "ColorBurn",
+                HardLight => "HardLight",
+                SoftLight => "SoftLight",
+                Difference => "Difference",
+                Exclusion => "Exclusion",
             },
-            NonSeperable(n) => {
-                match n {
-                    Hue => "Hue",
-                    Saturation => "Saturation",
-                    Color => "Color",
-                    Luminosity => "Luminosity",
-                }
-            }
+            NonSeperable(n) => match n {
+                Hue => "Hue",
+                Saturation => "Saturation",
+                Color => "Color",
+                Luminosity => "Luminosity",
+            },
         };
 
         Name(blend_mode_str.as_bytes().to_vec())
@@ -1323,9 +1226,7 @@ pub enum RenderingIntent {
 
 /* ri name */
 impl RenderingIntent {
-    pub fn into_stream_op(self)
-    -> Vec<Operation>
-    {
+    pub fn into_stream_op(self) -> Vec<Operation> {
         use self::RenderingIntent::*;
         let rendering_intent_string = match self {
             AbsoluteColorimetric => "AbsoluteColorimetric",
@@ -1334,18 +1235,19 @@ impl RenderingIntent {
             Perceptual => "Perceptual",
         };
 
-        vec![ Operation::new("ri", vec![ Name(rendering_intent_string.as_bytes().to_vec()) ]) ]
+        vec![Operation::new(
+            "ri",
+            vec![Name(rendering_intent_string.as_bytes().to_vec())],
+        )]
     }
 }
 
 /* RI name , only to be used in graphics state dictionary */
-impl Into<lopdf::Object> for RenderingIntent {
+impl From<RenderingIntent> for lopdf::Object {
     /// Consumes the object and converts it to an PDF object
-    fn into(self)
-    -> lopdf::Object
-    {
+    fn from(val: RenderingIntent) -> Self {
         use self::RenderingIntent::*;
-        let rendering_intent_string = match self {
+        let rendering_intent_string = match val {
             AbsoluteColorimetric => "AbsoluteColorimetric",
             RelativeColorimetric => "RelativeColorimetric",
             Saturation => "Saturation",
@@ -1378,7 +1280,6 @@ pub enum SoftMaskFunction {
     GroupAlpha,
     //
     GroupLuminosity,
-
 }
 /// __See PDF Reference Page 216__ - Line join style
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -1399,12 +1300,10 @@ pub enum LineJoinStyle {
     Limit,
 }
 
-impl Into<i64> for LineJoinStyle {
-    fn into(self)
-    -> i64
-    {
+impl From<LineJoinStyle> for i64 {
+    fn from(val: LineJoinStyle) -> Self {
         use self::LineJoinStyle::*;
-        match self {
+        match val {
             Miter => 0,
             Round => 1,
             Limit => 2,
@@ -1412,20 +1311,16 @@ impl Into<i64> for LineJoinStyle {
     }
 }
 
-impl Into<Operation> for LineJoinStyle {
-    fn into(self)
-    -> Operation
-    {
-        let line_join_num: i64 = self.into();
+impl From<LineJoinStyle> for Operation {
+    fn from(val: LineJoinStyle) -> Self {
+        let line_join_num: i64 = val.into();
         Operation::new("j", vec![Integer(line_join_num)])
     }
 }
 
-impl Into<lopdf::Object> for LineJoinStyle {
-    fn into(self)
-    -> lopdf::Object
-    {
-        Integer(self.into())
+impl From<LineJoinStyle> for lopdf::Object {
+    fn from(val: LineJoinStyle) -> Self {
+        Integer(val.into())
     }
 }
 
@@ -1443,12 +1338,10 @@ pub enum LineCapStyle {
     ProjectingSquare,
 }
 
-impl Into<i64> for LineCapStyle {
-    fn into(self)
-    -> i64
-    {
+impl From<LineCapStyle> for i64 {
+    fn from(val: LineCapStyle) -> Self {
         use self::LineCapStyle::*;
-        match self {
+        match val {
             Butt => 0,
             Round => 1,
             ProjectingSquare => 2,
@@ -1456,24 +1349,20 @@ impl Into<i64> for LineCapStyle {
     }
 }
 
-impl Into<Operation> for LineCapStyle {
-    fn into(self)
-    -> Operation
-    {
-        Operation::new("J", vec![Integer(self.into())])
+impl From<LineCapStyle> for Operation {
+    fn from(val: LineCapStyle) -> Self {
+        Operation::new("J", vec![Integer(val.into())])
     }
 }
 
-impl Into<lopdf::Object> for LineCapStyle {
-    fn into(self)
-    -> lopdf::Object
-    {
-        Integer(self.into())
+impl From<LineCapStyle> for lopdf::Object {
+    fn from(val: LineCapStyle) -> Self {
+        Integer(val.into())
     }
 }
 
 /// Line dash pattern is made up of a total width
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, Default)]
 pub struct LineDashPattern {
     /// Offset at which the dashing pattern should start, measured from the beginning ot the line
     /// Default: 0 (start directly where the line starts)
@@ -1493,86 +1382,58 @@ pub struct LineDashPattern {
     pub gap_3: Option<i64>,
 }
 
-impl LineDashPattern {
-    /// Creates a new dash pattern
-    pub fn new(offset: i64, dash_1: Option<i64>, gap_1: Option<i64>, dash_2: Option<i64>, gap_2: Option<i64>, dash_3: Option<i64>, gap_3: Option<i64>)
-    -> Self
-    {
-        Self { offset, dash_1, gap_1, dash_2, gap_2, dash_3, gap_3 }
-    }
-
-    /// Creates a new dash pattern
-    pub fn default()
-    -> Self
-    {
-        Self { offset: 0, dash_1: None, gap_1: None, dash_2: None, gap_2: None, dash_3: None, gap_3: None }
-    }
-}
+// impl LineDashPattern {
+//     /// Creates a new dash pattern
+//     pub fn new(
+//         offset: i64,
+//         dash_1: Option<i64>,
+//         gap_1: Option<i64>,
+//         dash_2: Option<i64>,
+//         gap_2: Option<i64>,
+//         dash_3: Option<i64>,
+//         gap_3: Option<i64>,
+//     ) -> Self {
+//         Self {
+//             offset,
+//             dash_1,
+//             gap_1,
+//             dash_2,
+//             gap_2,
+//             dash_3,
+//             gap_3,
+//         }
+//     }
+// }
 
 // conversion into a dash array for reuse in operation / gs dictionary
-impl Into<(Vec<i64>, i64)> for LineDashPattern {
-    #[cfg_attr(feature = "cargo-clippy", allow(never_loop))]
-    #[cfg_attr(feature = "cargo-clippy", allow(while_let_loop))]
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_return))]
-    fn into(self)
-    -> (Vec<i64>, i64)
-    {
-        let mut dash_array = Vec::<i64>::new();
-
-        // note: it may be that PDF allows more than 6 operators.
-        // I've not seen it in practise, though
-
-        // break as soon as we encounter a None
-        loop {
-
-            if let Some(d1) = self.dash_1 {
-                dash_array.push(d1);
-            } else { break; }
-
-            if let Some(g1) = self.gap_1 {
-                dash_array.push(g1);
-            } else { break; }
-
-            if let Some(d2) = self.dash_2 {
-                dash_array.push(d2);
-            } else { break; }
-
-            if let Some(g2) = self.gap_2 {
-                dash_array.push(g2);
-            } else { break; }
-
-            if let Some(d3) = self.dash_3 {
-                dash_array.push(d3);
-            } else { break; }
-
-            if let Some(g3) = self.gap_3 {
-                dash_array.push(g3);
-            } else { break; }
-
-            break;
-        }
-
-        return (dash_array, self.offset);
+impl From<LineDashPattern> for (Vec<i64>, i64) {
+    fn from(val: LineDashPattern) -> Self {
+        (
+            [
+                val.dash_1, val.gap_1, val.dash_2, val.gap_2, val.dash_3, val.gap_3,
+            ]
+            .iter()
+            .copied()
+            .take_while(Option::is_some)
+            .flatten()
+            .collect(),
+            val.offset,
+        )
     }
-
 }
 
-impl Into<Operation> for LineDashPattern {
-    fn into(self)
-    -> Operation
-    {
-        let (dash_array, offset) = self.into();
+impl From<LineDashPattern> for Operation {
+    fn from(val: LineDashPattern) -> Self {
+        let (dash_array, offset) = val.into();
         let dash_array_ints = dash_array.into_iter().map(Integer).collect();
         Operation::new("d", vec![Array(dash_array_ints), Integer(offset)])
     }
 }
 
-impl Into<lopdf::Object> for LineDashPattern {
-    fn into(self)
-    -> lopdf::Object
-    {
+impl From<LineDashPattern> for lopdf::Object {
+    fn from(val: LineDashPattern) -> Self {
         use lopdf::Object::*;
-        let (dash_array, offset) = self.into();
+        let (dash_array, offset) = val.into();
         let mut dash_array_ints: Vec<lopdf::Object> = dash_array.into_iter().map(Integer).collect();
         dash_array_ints.push(Integer(offset));
         Array(dash_array_ints)

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,13 +1,13 @@
 #![allow(trivial_numeric_casts)]
 
 //! Embedding fonts in 2D for Pdf
+use crate::{Error, PdfError};
 use lopdf;
-use lopdf::{Stream as LoStream, Dictionary as LoDictionary};
 use lopdf::StringFormat;
+use lopdf::{Dictionary as LoDictionary, Stream as LoStream};
 use owned_ttf_parser::{AsFaceRef as _, Face, OwnedFace};
 use std::collections::BTreeMap;
 use std::iter::FromIterator;
-use {Error, PdfError};
 
 /// The font
 #[derive(Debug, Clone, PartialEq)]
@@ -37,34 +37,34 @@ pub enum BuiltinFont {
     ZapfDingbats,
 }
 
-impl Into<&'static str> for BuiltinFont {
-    fn into(self) -> &'static str {
-        use BuiltinFont::*;
-        match self {
-            TimesRoman              => "Times-Roman",
-            TimesBold               => "Times-Bold",
-            TimesItalic             => "Times-Italic",
-            TimesBoldItalic         => "Times-BoldItalic",
-            Helvetica               => "Helvetica",
-            HelveticaBold           => "Helvetica-Bold",
-            HelveticaOblique        => "Helvetica-Oblique",
-            HelveticaBoldOblique    => "Helvetica-BoldOblique",
-            Courier                 => "Courier",
-            CourierOblique          => "Courier-Oblique",
-            CourierBold             => "Courier-Bold",
-            CourierBoldOblique      => "Courier-BoldOblique",
-            Symbol                  => "Symbol",
-            ZapfDingbats            => "ZapfDingbats",
+impl From<BuiltinFont> for &'static str {
+    fn from(val: BuiltinFont) -> Self {
+        use crate::BuiltinFont::*;
+        match val {
+            TimesRoman => "Times-Roman",
+            TimesBold => "Times-Bold",
+            TimesItalic => "Times-Italic",
+            TimesBoldItalic => "Times-BoldItalic",
+            Helvetica => "Helvetica",
+            HelveticaBold => "Helvetica-Bold",
+            HelveticaOblique => "Helvetica-Oblique",
+            HelveticaBoldOblique => "Helvetica-BoldOblique",
+            Courier => "Courier",
+            CourierOblique => "Courier-Oblique",
+            CourierBold => "Courier-Bold",
+            CourierBoldOblique => "Courier-BoldOblique",
+            Symbol => "Symbol",
+            ZapfDingbats => "ZapfDingbats",
         }
     }
 }
 
-impl Into<LoDictionary> for BuiltinFont {
-    fn into(self) -> LoDictionary {
+impl From<BuiltinFont> for LoDictionary {
+    fn from(val: BuiltinFont) -> Self {
         use lopdf::Object;
         use lopdf::Object::*;
 
-        let font_id: &'static str = self.into();
+        let font_id: &'static str = val.into();
 
         // Begin setting required font attributes
         let font_vec: Vec<(::std::string::String, Object)> = vec![
@@ -109,12 +109,10 @@ pub enum TextRenderingMode {
     Clip,
 }
 
-impl Into<i64> for TextRenderingMode {
-    fn into(self)
-    -> i64
-    {
-        use TextRenderingMode::*;
-        match self {
+impl From<TextRenderingMode> for i64 {
+    fn from(val: TextRenderingMode) -> Self {
+        use crate::TextRenderingMode::*;
+        match val {
             Fill => 0,
             Stroke => 1,
             FillStroke => 2,
@@ -128,7 +126,6 @@ impl Into<i64> for TextRenderingMode {
 }
 
 impl ExternalFont {
-
     /// Creates a new font. The `index` is used for naming / identifying the font
     ///
     /// This method uses [`owned_ttf_parser`][] to parse the font data.  If you want to use a different
@@ -136,8 +133,9 @@ impl ExternalFont {
     ///
     /// [`owned_ttf_parser`]: https://docs.rs/owned_ttf_parser/latest/owned_ttf_parser/
     /// [`with_font_data`]: #method.with_font_data
-    pub fn new<R>(mut font_stream: R, font_index: usize)
-    -> Result<Self, Error> where R: ::std::io::Read
+    pub fn new<R>(mut font_stream: R, font_index: usize) -> Result<Self, Error>
+    where
+        R: ::std::io::Read,
     {
         // read font from stream and parse font metrics
         let mut buf = Vec::<u8>::new();
@@ -150,7 +148,7 @@ impl ExternalFont {
 
     /// Creates a new font. The `index` is used for naming / identifying the font
     pub fn with_font_data(bytes: Vec<u8>, font_index: usize, font_data: Box<dyn FontData>) -> Self {
-        let face_name = format!("F{}", font_index);
+        let face_name = format!("F{font_index}");
         Self {
             font_bytes: bytes,
             font_data,
@@ -160,9 +158,7 @@ impl ExternalFont {
     }
 
     /// Takes the font and adds it to the document and consumes the font
-    pub(crate) fn into_with_document(self, doc: &mut lopdf::Document)
-    -> LoDictionary
-    {
+    pub(crate) fn into_with_document(self, doc: &mut lopdf::Document) -> LoDictionary {
         use lopdf::Object;
         use lopdf::Object::*;
 
@@ -172,10 +168,9 @@ impl ExternalFont {
         let face_metrics = self.font_data.font_metrics();
 
         let font_stream = LoStream::new(
-            LoDictionary::from_iter(vec![
-                ("Length1", Integer(self.font_bytes.len() as i64)),
-                ]),
-            self.font_bytes)
+            LoDictionary::from_iter(vec![("Length1", Integer(self.font_bytes.len() as i64))]),
+            self.font_bytes,
+        )
         .with_compression(false); /* important! font stream must not be compressed! */
 
         // Begin setting required font attributes
@@ -220,8 +215,10 @@ impl ExternalFont {
                 }
 
                 total_width += glyph_metrics.width;
-                cmap.insert(glyph_id as u32,
-                            (c as u32, glyph_metrics.width as u32, glyph_metrics.height as u32));
+                cmap.insert(
+                    glyph_id as u32,
+                    (c as u32, glyph_metrics.width, glyph_metrics.height),
+                );
             }
         }
 
@@ -235,7 +232,7 @@ impl ExternalFont {
         // Since the glyph IDs are sequential, all we really have to do is to enumerate the vector
         // and create buckets of 100 / rest to 256 if needed
 
-        let mut cur_first_bit: u16 = 0_u16;     // current first bit of the glyph id (0x10 or 0x12) for example
+        let mut cur_first_bit: u16 = 0_u16; // current first bit of the glyph id (0x10 or 0x12) for example
 
         let mut all_cmap_blocks = Vec::new();
 
@@ -243,7 +240,6 @@ impl ExternalFont {
             let mut current_cmap_block = Vec::new();
 
             for (glyph_id, unicode_width_tuple) in &cmap {
-
                 if (*glyph_id >> 8) as u16 != cur_first_bit || current_cmap_block.len() >= 100 {
                     // end the current (beginbfchar endbfchar) block
                     all_cmap_blocks.push(current_cmap_block.clone());
@@ -254,14 +250,15 @@ impl ExternalFont {
                 let (unicode, width, _) = *unicode_width_tuple;
                 current_cmap_block.push((*glyph_id, unicode));
                 widths.push((*glyph_id, width));
-            };
+            }
 
             all_cmap_blocks.push(current_cmap_block);
         }
 
         let cid_to_unicode_map = generate_cid_to_unicode_map(face_name.clone(), all_cmap_blocks);
 
-        let cid_to_unicode_map_stream = LoStream::new(LoDictionary::new(), cid_to_unicode_map.as_bytes().to_vec());
+        let cid_to_unicode_map_stream =
+            LoStream::new(LoDictionary::new(), cid_to_unicode_map.as_bytes().to_vec());
         let cid_to_unicode_map_stream_id = doc.add_object(cid_to_unicode_map_stream);
 
         // encode widths / heights so that they fit into what PDF expects
@@ -296,29 +293,44 @@ impl ExternalFont {
         widths_list.push(Array(current_width_vec.drain(..).collect()));
 
         let w = {
-            if self.vertical_writing { ("W2",  Array(widths_list)) }
-            else { ("W",  Array(widths_list)) }
+            if self.vertical_writing {
+                ("W2", Array(widths_list))
+            } else {
+                ("W", Array(widths_list))
+            }
         };
 
         // default width for characters
         let dw = {
-            if self.vertical_writing { ("DW2", Integer(1000)) }
-            else { ("DW", Integer(1000)) }
+            if self.vertical_writing {
+                ("DW2", Integer(1000))
+            } else {
+                ("DW", Integer(1000))
+            }
         };
 
         let mut desc_fonts = LoDictionary::from_iter(vec![
             ("Type", Name("Font".into())),
             ("Subtype", Name("CIDFontType2".into())),
-            ("BaseFont", Name(face_name.clone().into())),
-            ("CIDSystemInfo", Dictionary(LoDictionary::from_iter(vec![
+            ("BaseFont", Name(face_name.into())),
+            (
+                "CIDSystemInfo",
+                Dictionary(LoDictionary::from_iter(vec![
                     ("Registry", String("Adobe".into(), StringFormat::Literal)),
                     ("Ordering", String("Identity".into(), StringFormat::Literal)),
                     ("Supplement", Integer(0)),
-            ]))),
-            w, dw,
+                ])),
+            ),
+            w,
+            dw,
         ]);
 
-        let font_bbox = vec![ Integer(0), Integer(max_height as i64), Integer(total_width as i64), Integer(max_height as i64) ];
+        let font_bbox = vec![
+            Integer(0),
+            Integer(max_height as i64),
+            Integer(total_width as i64),
+            Integer(max_height as i64),
+        ];
         font_descriptor_vec.push(("FontFile2".into(), Reference(doc.add_object(font_stream))));
 
         // although the following entry is technically not needed, Adobe Reader needs it
@@ -328,7 +340,10 @@ impl ExternalFont {
 
         desc_fonts.set("FontDescriptor", Reference(font_descriptor_vec_id));
 
-        font_vec.push(("DescendantFonts".into(), Array(vec![Dictionary(desc_fonts)])));
+        font_vec.push((
+            "DescendantFonts".into(),
+            Array(vec![Dictionary(desc_fonts)]),
+        ));
         font_vec.push(("ToUnicode".into(), Reference(cid_to_unicode_map_stream_id)));
 
         LoDictionary::from_iter(font_vec)
@@ -341,13 +356,16 @@ type CmapBlock = Vec<(GlyphId, UnicodeCodePoint)>;
 
 /// Generates a CMAP (character map) from valid cmap blocks
 fn generate_cid_to_unicode_map(face_name: String, all_cmap_blocks: Vec<CmapBlock>) -> String {
+    let mut cid_to_unicode_map =
+        format!(include_str!("../assets/gid_to_unicode_beg.txt"), face_name);
 
-    let mut cid_to_unicode_map = format!(include_str!("../assets/gid_to_unicode_beg.txt"), face_name);
-
-    for cmap_block in all_cmap_blocks.into_iter().filter(|block| !block.is_empty() || block.len() < 100) {
+    for cmap_block in all_cmap_blocks
+        .into_iter()
+        .filter(|block| !block.is_empty() || block.len() < 100)
+    {
         cid_to_unicode_map.push_str(format!("{} beginbfchar\r\n", cmap_block.len()).as_str());
         for (glyph_id, unicode) in cmap_block {
-            cid_to_unicode_map.push_str(format!("<{:04x}> <{:04x}>\n", glyph_id, unicode).as_str());
+            cid_to_unicode_map.push_str(format!("<{glyph_id:04x}> <{unicode:04x}>\n").as_str());
         }
         cid_to_unicode_map.push_str("endbfchar\r\n");
     }
@@ -383,12 +401,11 @@ pub struct DirectFontRef {
 
 impl IndirectFontRef {
     /// Creates a new IndirectFontRef from an index
-    pub fn new<S>(name: S)
-    -> Self where S: Into<String>
+    pub fn new<S>(name: S) -> Self
+    where
+        S: Into<String>,
     {
-        Self {
-            name: name.into(),
-        }
+        Self { name: name.into() }
     }
 }
 
@@ -399,18 +416,13 @@ pub struct FontList {
 }
 
 impl FontList {
-
     /// Creates a new FontList
-    pub fn new()
-    -> Self
-    {
+    pub fn new() -> Self {
         Self::default()
     }
 
     /// Adds a font to the FontList
-    pub fn add_font(&mut self, font_ref: IndirectFontRef, font: DirectFontRef)
-    -> IndirectFontRef
-    {
+    pub fn add_font(&mut self, font_ref: IndirectFontRef, font: DirectFontRef) -> IndirectFontRef {
         self.fonts.insert(font_ref.clone(), font);
         font_ref
     }
@@ -418,47 +430,40 @@ impl FontList {
     /// Turns an indirect font reference into a direct one
     /// (Warning): clones the direct font reference
     #[inline]
-    pub fn get_font(&self, font: &IndirectFontRef)
-    -> Option<DirectFontRef>
-    {
-        let font_ref = self.fonts.get(font);
-        if let Some(r) = font_ref {
-            Some(r.clone())
-        } else {
-            None
-        }
+    pub fn get_font(&self, font: &IndirectFontRef) -> Option<DirectFontRef> {
+        self.fonts.get(font).cloned()
     }
 
     /// Returns the number of fonts currenly in use
     #[inline]
-    pub fn len(&self)
-    -> usize
-    {
+    pub fn len(&self) -> usize {
         self.fonts.len()
     }
 
     /// Returns if the font list is empty
     #[inline]
-    pub fn is_empty(&self)
-    -> bool
-    {
+    pub fn is_empty(&self) -> bool {
         self.fonts.is_empty()
     }
 
     /// Converts the fonts into a dictionary
-    pub(crate) fn into_with_document(self, doc: &mut lopdf::Document)
-    ->lopdf::Dictionary
-    {
+    pub(crate) fn into_with_document(self, doc: &mut lopdf::Document) -> lopdf::Dictionary {
         let mut font_dict = lopdf::Dictionary::new();
 
         for (indirect_ref, direct_font_ref) in self.fonts {
             let font_dict_collected = match direct_font_ref.data {
                 Font::ExternalFont(font) => font.into_with_document(doc),
-                Font::BuiltinFont(font)  => font.into(),
+                Font::BuiltinFont(font) => font.into(),
             };
 
-            doc.objects.insert(direct_font_ref.inner_obj, lopdf::Object::Dictionary(font_dict_collected));
-            font_dict.set(indirect_ref.name,lopdf::Object::Reference(direct_font_ref.inner_obj));
+            doc.objects.insert(
+                direct_font_ref.inner_obj,
+                lopdf::Object::Dictionary(font_dict_collected),
+            );
+            font_dict.set(
+                indirect_ref.name,
+                lopdf::Object::Reference(direct_font_ref.inner_obj),
+            );
         }
 
         font_dict
@@ -542,9 +547,7 @@ impl FontData for TtfFace {
     }
 
     fn glyph_id(&self, c: char) -> Option<u16> {
-        self.face()
-            .glyph_index(c)
-            .map(|id| id.0)
+        self.face().glyph_index(c).map(|id| id.0)
     }
 
     fn glyph_ids(&self) -> std::collections::HashMap<u16, char> {
@@ -552,7 +555,8 @@ impl FontData for TtfFace {
             .face()
             .character_mapping_subtables()
             .filter(|s| s.is_unicode());
-        let mut map = std::collections::HashMap::with_capacity(self.face().number_of_glyphs().into());
+        let mut map =
+            std::collections::HashMap::with_capacity(self.face().number_of_glyphs().into());
         for subtable in subtables {
             subtable.codepoints(|c| {
                 use std::convert::TryFrom as _;
@@ -571,9 +575,11 @@ impl FontData for TtfFace {
         let glyph_id = owned_ttf_parser::GlyphId(glyph_id);
         if let Some(width) = self.face().glyph_hor_advance(glyph_id) {
             let width = width as u32;
-            let height = self.face().glyph_bounding_box(glyph_id).map(|bbox| {
-                bbox.y_max - bbox.y_min - self.face().descender()
-            }).unwrap_or(1000) as u32;
+            let height = self
+                .face()
+                .glyph_bounding_box(glyph_id)
+                .map(|bbox| bbox.y_max - bbox.y_min - self.face().descender())
+                .unwrap_or(1000) as u32;
             Some(GlyphMetrics { width, height })
         } else {
             None

--- a/src/indices.rs
+++ b/src/indices.rs
@@ -16,10 +16,9 @@ pub struct PdfContentIndex(pub(crate) usize);
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct FontIndex(pub(crate) PdfContentIndex);
 
-impl Into<PdfContentIndex> for FontIndex {
-    fn into(self) -> PdfContentIndex
-    {
-        self.0
+impl From<FontIndex> for PdfContentIndex {
+    fn from(val: FontIndex) -> Self {
+        val.0
     }
 }
 
@@ -27,9 +26,8 @@ impl Into<PdfContentIndex> for FontIndex {
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct SvgIndex(pub(crate) PdfContentIndex);
 
-impl Into<PdfContentIndex> for SvgIndex {
-    fn into(self) -> PdfContentIndex
-    {
-        self.0
+impl From<SvgIndex> for PdfContentIndex {
+    fn from(val: SvgIndex) -> Self {
+        val.0
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,60 +108,61 @@
 //! current_layer.add_shape(line2);
 //! ```
 //!
-//! ### Adding images
-//!
-//! Note: Images only get compressed in release mode. You might get huge PDFs (6 or more MB) in
-//! debug mode. In release mode, the compression makes these files much smaller (~ 100 - 200 KB).
-//!
-//! To make this process faster, use `BufReader` instead of directly reading from the file.
-//! Images are currently not a top priority.
-//!
-//! Scaling of images is implicitly done to fit one pixel = one dot at 300 dpi.
-//!
-//! ```rust
-//! // Compile with --feature="embedded_images"
-//! extern crate printpdf;
-//!
-//! // imports the `image` library with the exact version that we are using
-//! use printpdf::*;
-//!
-//! use std::convert::From;
-//! use std::convert::TryFrom;
-//! use std::fs::File;
-//!
-//! fn main() {
-//!     let (doc, page1, layer1) = PdfDocument::new("PDF_Document_title", Mm(247.0), Mm(210.0), "Layer 1");
-//!     let current_layer = doc.get_page(page1).get_layer(layer1);
-//!
-//!     // currently, the only reliable file formats are bmp/jpeg/png
-//!     // this is an issue of the image library, not a fault of printpdf
-//!     let mut image_file = File::open("assets/img/BMP_test.bmp").unwrap();
-//!     let image = Image::try_from(image_crate::codecs::bmp::BmpDecoder::new(&mut image_file).unwrap()).unwrap();
-//!
-//!     // translate x, translate y, rotate, scale x, scale y
-//!     // by default, an image is optimized to 300 DPI (if scale is None)
-//!     // rotations and translations are always in relation to the lower left corner
-//!     image.add_to_layer(current_layer.clone(), ImageTransform::default());
-//!
-//!     // you can also construct images manually from your data:
-//!     let mut image_file_2 = ImageXObject {
-//!         width: Px(200),
-//!         height: Px(200),
-//!         color_space: ColorSpace::Greyscale,
-//!         bits_per_component: ColorBits::Bit8,
-//!         interpolate: true,
-//!         /* put your bytes here. Make sure the total number of bytes =
-//!            width * height * (bytes per component * number of components)
-//!            (e.g. 2 (bytes) x 3 (colors) for RGB 16bit) */
-//!         image_data: Vec::new(),
-//!         image_filter: None, /* does not work yet */
-//!         clipping_bbox: None, /* doesn't work either, untested */
-//!     };
-//!
-//!     let image2 = Image::from(image_file_2);
-//! }
-//! ```
-//!
+#![cfg_attr(feature = "embedded_images", doc = r##"
+### Adding images
+
+Note: Images only get compressed in release mode. You might get huge PDFs (6 or more MB) in
+debug mode. In release mode, the compression makes these files much smaller (~ 100 - 200 KB).
+
+To make this process faster, use `BufReader` instead of directly reading from the file.
+Images are currently not a top priority.
+
+Scaling of images is implicitly done to fit one pixel = one dot at 300 dpi.
+
+```rust
+// Compile with --feature="embedded_images"
+extern crate printpdf;
+
+// imports the `image` library with the exact version that we are using
+use printpdf::*;
+
+use std::convert::From;
+use std::convert::TryFrom;
+use std::fs::File;
+
+fn main() {
+    let (doc, page1, layer1) = PdfDocument::new("PDF_Document_title", Mm(247.0), Mm(210.0), "Layer 1");
+    let current_layer = doc.get_page(page1).get_layer(layer1);
+
+    // currently, the only reliable file formats are bmp/jpeg/png
+    // this is an issue of the image library, not a fault of printpdf
+    let mut image_file = File::open("assets/img/BMP_test.bmp").unwrap();
+    let image = Image::try_from(image_crate::codecs::bmp::BmpDecoder::new(&mut image_file).unwrap()).unwrap();
+
+    // translate x, translate y, rotate, scale x, scale y
+    // by default, an image is optimized to 300 DPI (if scale is None)
+    // rotations and translations are always in relation to the lower left corner
+    image.add_to_layer(current_layer.clone(), ImageTransform::default());
+
+    // you can also construct images manually from your data:
+    let mut image_file_2 = ImageXObject {
+        width: Px(200),
+        height: Px(200),
+        color_space: ColorSpace::Greyscale,
+        bits_per_component: ColorBits::Bit8,
+        interpolate: true,
+        /* put your bytes here. Make sure the total number of bytes =
+           width * height * (bytes per component * number of components)
+           (e.g. 2 (bytes) x 3 (colors) for RGB 16bit) */
+        image_data: Vec::new(),
+        image_filter: None, /* does not work yet */
+        clipping_bbox: None, /* doesn't work either, untested */
+    };
+
+    let image2 = Image::from(image_file_2);
+}
+```
+"##)]
 //! ### Adding fonts
 //!
 //! Note: Fonts are shared between pages. This means that they are added to the document first
@@ -306,40 +307,26 @@
 //!
 //! [PDF X/3 technical notes](http://www.pdfxreport.com/lib/exe/fetch.php?media=en:technote_pdfx_checks.pdf)
 
-#![warn(missing_copy_implementations,
-        trivial_numeric_casts,
-        trivial_casts,
-        unused_extern_crates,
-        unused_import_braces,
-        unused_qualifications)]
-
-#![cfg_attr(feature="clippy", warn(cast_possible_truncation))]
-#![cfg_attr(feature="clippy", warn(cast_possible_truncation))]
-#![cfg_attr(feature="clippy", warn(cast_precision_loss))]
-#![cfg_attr(feature="clippy", warn(cast_sign_loss))]
-#![cfg_attr(feature="clippy", warn(missing_docs_in_private_items))]
-#![cfg_attr(feature="clippy", warn(mut_mut))]
-
+#![warn(
+    missing_copy_implementations,
+    trivial_numeric_casts,
+    trivial_casts,
+    unused_extern_crates,
+    unused_import_braces,
+    unused_qualifications
+)]
 // Disallow `println!`. Use `debug!` for debug output
 // (which is provided by the `log` crate).
-#![cfg_attr(feature="clippy", warn(print_stdout))]
-
-#![cfg_attr(all(not(test), feature="clippy"), warn(result_unwrap_used))]
-#![cfg_attr(feature="clippy", warn(unseparated_literal_suffix))]
-#![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
+#![cfg_attr(all(not(test), feature = "clippy"), warn(result_unwrap_used))]
 
 #[cfg(feature = "logging")]
 #[macro_use]
 pub extern crate log;
 #[cfg(feature = "embedded_images")]
 pub extern crate image as image_crate;
-pub extern crate lopdf;
-extern crate owned_ttf_parser;
-#[cfg(feature = "svg")]
-extern crate pdf_writer;
-extern crate time;
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 extern crate js_sys;
+pub use lopdf;
 
 pub mod color;
 pub mod ctm;
@@ -376,68 +363,66 @@ pub(crate) mod glob_defines {
     /// ## General graphics state
 
     /// Set line width
-    pub const OP_PATH_STATE_SET_LINE_WIDTH: &str                 = "w";
+    pub const OP_PATH_STATE_SET_LINE_WIDTH: &str = "w";
     /// Set line join
-    pub const OP_PATH_STATE_SET_LINE_JOIN: &str                  = "J";
+    pub const OP_PATH_STATE_SET_LINE_JOIN: &str = "J";
     /// Set line cap
-    pub const OP_PATH_STATE_SET_LINE_CAP: &str                   = "j";
+    pub const OP_PATH_STATE_SET_LINE_CAP: &str = "j";
     /// Set miter limit
-    pub const OP_PATH_STATE_SET_MITER_LIMIT: &str                = "M";
+    pub const OP_PATH_STATE_SET_MITER_LIMIT: &str = "M";
     /// Set line dash pattern
-    pub const OP_PATH_STATE_SET_LINE_DASH: &str                  = "d";
+    pub const OP_PATH_STATE_SET_LINE_DASH: &str = "d";
     /// Set rendering intent
-    pub const OP_PATH_STATE_SET_RENDERING_INTENT: &str           = "ri";
+    pub const OP_PATH_STATE_SET_RENDERING_INTENT: &str = "ri";
     /// Set flatness tolerance
-    pub const OP_PATH_STATE_SET_FLATNESS_TOLERANCE: &str         = "i";
+    pub const OP_PATH_STATE_SET_FLATNESS_TOLERANCE: &str = "i";
     /// (PDF 1.2) Set graphics state from parameter dictionary
-    pub const OP_PATH_STATE_SET_GS_FROM_PARAM_DICT: &str         = "gs";
-
+    pub const OP_PATH_STATE_SET_GS_FROM_PARAM_DICT: &str = "gs";
 
     /// ## Color
 
     /// stroking color space (PDF 1.1)
-    pub const OP_COLOR_SET_STROKE_CS: &str                       = "CS";
+    pub const OP_COLOR_SET_STROKE_CS: &str = "CS";
     /// non-stroking color space (PDF 1.1)
-    pub const OP_COLOR_SET_FILL_CS: &str                         = "cs";
+    pub const OP_COLOR_SET_FILL_CS: &str = "cs";
     /// set stroking color (PDF 1.1)
-    pub const OP_COLOR_SET_STROKE_COLOR: &str                    = "SC";
+    pub const OP_COLOR_SET_STROKE_COLOR: &str = "SC";
     /// set stroking color (PDF 1.2) with support for ICC, etc.
-    pub const OP_COLOR_SET_STROKE_COLOR_ICC: &str                = "SCN";
+    pub const OP_COLOR_SET_STROKE_COLOR_ICC: &str = "SCN";
     /// set fill color (PDF 1.1)
-    pub const OP_COLOR_SET_FILL_COLOR: &str                      = "sc";
+    pub const OP_COLOR_SET_FILL_COLOR: &str = "sc";
     /// set fill color (PDF 1.2) with support for Icc, etc.
-    pub const OP_COLOR_SET_FILL_COLOR_ICC: &str                  = "scn";
+    pub const OP_COLOR_SET_FILL_COLOR_ICC: &str = "scn";
 
     /// Set the stroking color space to DeviceGray
-    pub const OP_COLOR_SET_STROKE_CS_DEVICEGRAY: &str            = "G";
+    pub const OP_COLOR_SET_STROKE_CS_DEVICEGRAY: &str = "G";
     /// Set the fill color space to DeviceGray
-    pub const OP_COLOR_SET_FILL_CS_DEVICEGRAY: &str              = "g";
+    pub const OP_COLOR_SET_FILL_CS_DEVICEGRAY: &str = "g";
     /// Set the stroking color space to DeviceRGB
-    pub const OP_COLOR_SET_STROKE_CS_DEVICERGB: &str             = "RG";
+    pub const OP_COLOR_SET_STROKE_CS_DEVICERGB: &str = "RG";
     /// Set the fill color space to DeviceRGB
-    pub const OP_COLOR_SET_FILL_CS_DEVICERGB: &str               = "rg";
+    pub const OP_COLOR_SET_FILL_CS_DEVICERGB: &str = "rg";
     /// Set the stroking color space to DeviceCMYK
-    pub const OP_COLOR_SET_STROKE_CS_DEVICECMYK: &str            = "K";
+    pub const OP_COLOR_SET_STROKE_CS_DEVICECMYK: &str = "K";
     /// Set the fill color to DeviceCMYK
-    pub const OP_COLOR_SET_FILL_CS_DEVICECMYK: &str              = "k";
-
+    pub const OP_COLOR_SET_FILL_CS_DEVICECMYK: &str = "k";
 
     /// Path construction
 
     /// Move to point
-    pub const OP_PATH_CONST_MOVE_TO: &str                        = "m";
+    pub const OP_PATH_CONST_MOVE_TO: &str = "m";
     /// Straight line to the two following points
-    pub const OP_PATH_CONST_LINE_TO: &str                        = "l";
+    pub const OP_PATH_CONST_LINE_TO: &str = "l";
     /// Cubic bezier over four following points
-    pub const OP_PATH_CONST_4BEZIER: &str                        = "c";
+    pub const OP_PATH_CONST_4BEZIER: &str = "c";
     /// Cubic bezier with two points in v1
-    pub const OP_PATH_CONST_3BEZIER_V1: &str                     = "v";
+    pub const OP_PATH_CONST_3BEZIER_V1: &str = "v";
     /// Cubic bezier with two points in v2
-    pub const OP_PATH_CONST_3BEZIER_V2: &str                     = "y";
+    pub const OP_PATH_CONST_3BEZIER_V2: &str = "y";
     /// Add rectangle to the path (width / height): x y width height re
-    pub const OP_PATH_CONST_RECT: &str                           = "re";
+    pub const OP_PATH_CONST_RECT: &str = "re";
     /// Close current sub-path (for appending custom patterns along line)
-    pub const OP_PATH_CONST_CLOSE_SUBPATH: &str                  = "h";
+    pub const OP_PATH_CONST_CLOSE_SUBPATH: &str = "h";
     /// Current path is a clip path, non-zero winding order (usually in like `h W S`)
     pub const OP_PATH_CONST_CLIP_NZ: &str = "W";
     /// Current path is a clip path, non-zero winding order
@@ -446,25 +431,25 @@ pub(crate) mod glob_defines {
     /// Path painting
 
     /// Stroke path
-    pub const OP_PATH_PAINT_STROKE: &str                         = "S";
+    pub const OP_PATH_PAINT_STROKE: &str = "S";
     /// Close and stroke path
-    pub const OP_PATH_PAINT_STROKE_CLOSE: &str                   = "s";
+    pub const OP_PATH_PAINT_STROKE_CLOSE: &str = "s";
     /// Fill path using nonzero winding number rule
-    pub const OP_PATH_PAINT_FILL_NZ: &str                        = "f";
+    pub const OP_PATH_PAINT_FILL_NZ: &str = "f";
     /// Fill path using nonzero winding number rule (obsolete)
-    pub const OP_PATH_PAINT_FILL_NZ_OLD: &str                    = "F";
+    pub const OP_PATH_PAINT_FILL_NZ_OLD: &str = "F";
     /// Fill path using even-odd rule
-    pub const OP_PATH_PAINT_FILL_EO: &str                        = "f*";
+    pub const OP_PATH_PAINT_FILL_EO: &str = "f*";
     /// Fill and stroke path using nonzero winding number rule
-    pub const OP_PATH_PAINT_FILL_STROKE_NZ: &str                 = "B";
+    pub const OP_PATH_PAINT_FILL_STROKE_NZ: &str = "B";
     /// Close, fill and stroke path using nonzero winding number rule
-    pub const OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ: &str           = "b";
+    pub const OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ: &str = "b";
     /// Fill and stroke path using even-odd rule
-    pub const OP_PATH_PAINT_FILL_STROKE_EO: &str                 = "B*";
+    pub const OP_PATH_PAINT_FILL_STROKE_EO: &str = "B*";
     /// Close, fill and stroke path using even odd rule
-    pub const OP_PATH_PAINT_FILL_STROKE_CLOSE_EO: &str           = "b*";
+    pub const OP_PATH_PAINT_FILL_STROKE_CLOSE_EO: &str = "b*";
     /// End path without filling or stroking
-    pub const OP_PATH_PAINT_END: &str                            = "n";
+    pub const OP_PATH_PAINT_END: &str = "n";
 }
 
 #[doc(inline)]

--- a/src/line.rs
+++ b/src/line.rs
@@ -1,13 +1,14 @@
-use lopdf;
-use glob_defines::{
-    OP_PATH_CONST_MOVE_TO, OP_PATH_CONST_3BEZIER_V1, OP_PATH_CONST_3BEZIER_V2, OP_PATH_CONST_4BEZIER,
-    OP_PATH_CONST_LINE_TO, OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ, OP_PATH_PAINT_FILL_NZ,
-    OP_PATH_PAINT_STROKE_CLOSE, OP_PATH_PAINT_STROKE, OP_PATH_PAINT_END, OP_PATH_CONST_CLIP_NZ,
+use crate::glob_defines::{
+    OP_PATH_CONST_3BEZIER_V1, OP_PATH_CONST_3BEZIER_V2, OP_PATH_CONST_4BEZIER,
+    OP_PATH_CONST_CLIP_NZ, OP_PATH_CONST_LINE_TO, OP_PATH_CONST_MOVE_TO, OP_PATH_PAINT_END,
+    OP_PATH_PAINT_FILL_NZ, OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ, OP_PATH_PAINT_STROKE,
+    OP_PATH_PAINT_STROKE_CLOSE,
 };
-use Point;
+use crate::Point;
+use lopdf;
 use std::iter::{FromIterator, IntoIterator};
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Line {
     /// 2D Points for the line
     pub points: Vec<(Point, bool)>,
@@ -21,33 +22,20 @@ pub struct Line {
     pub is_clipping_path: bool,
 }
 
-impl Default for Line {
-    fn default() -> Self {
-        Self {
-            points: Vec::new(),
-            is_closed: false,
-            has_fill: false,
-            has_stroke: false,
-            is_clipping_path: false,
-        }
-    }
-}
-
 impl FromIterator<(Point, bool)> for Line {
-    fn from_iter<I: IntoIterator<Item=(Point, bool)>>(iter: I) -> Self {
+    fn from_iter<I: IntoIterator<Item = (Point, bool)>>(iter: I) -> Self {
         let mut points = Vec::new();
         for i in iter {
             points.push(i);
         }
         Line {
-            points: points,
-            .. Default::default()
+            points,
+            ..Default::default()
         }
     }
 }
 
 impl Line {
-
     /// Sets if the line is closed or not
     #[inline]
     pub fn set_closed(&mut self, is_closed: bool) {
@@ -72,15 +60,18 @@ impl Line {
         self.is_clipping_path = is_clipping_path;
     }
 
-    pub fn into_stream_op(self)
-    -> Vec<lopdf::content::Operation>
-    {
+    pub fn into_stream_op(self) -> Vec<lopdf::content::Operation> {
         use lopdf::content::Operation;
         let mut operations = Vec::<Operation>::new();
 
-        if self.points.is_empty() { return operations; };
+        if self.points.is_empty() {
+            return operations;
+        };
 
-        operations.push(Operation::new(OP_PATH_CONST_MOVE_TO, vec![self.points[0].0.x.into(), self.points[0].0.y.into()]));
+        operations.push(Operation::new(
+            OP_PATH_CONST_MOVE_TO,
+            vec![self.points[0].0.x.into(), self.points[0].0.y.into()],
+        ));
 
         // Skip first element
         let mut current = 1;
@@ -89,26 +80,41 @@ impl Line {
         // Loop over every points, determine if v, y, c or l operation should be used and build
         // curve / line accordingly
         while current < max_len {
-            let p1 = &self.points[current - 1];                      // prev pt
-            let p2 = &self.points[current];                          // current pt
-
+            let p1 = &self.points[current - 1]; // prev pt
+            let p2 = &self.points[current]; // current pt
 
             if p1.1 && p2.1 {
                 // current point is a bezier handle
                 // valid bezier curve must have two sequential bezier handles
                 // we also can"t build a valid cubic bezier curve if the cuve contains less than
                 // four points. If p3 or p4 is marked as "next point is bezier handle" or not, doesn"t matter
-                if let Some(p3) = self.points.get(current + 1){
-                    if let Some(p4) = self.points.get(current + 2){
+                if let Some(p3) = self.points.get(current + 1) {
+                    if let Some(p4) = self.points.get(current + 2) {
                         if p1.0 == p2.0 {
                             // first control point coincides with initial point of curve
-                            operations.push(Operation::new(OP_PATH_CONST_3BEZIER_V1, vec![p3.0.x.into(), p3.0.y.into(), p4.0.x.into(), p4.0.y.into()]));
-                        }else if p2.0 == p3.0 {
+                            operations.push(Operation::new(
+                                OP_PATH_CONST_3BEZIER_V1,
+                                vec![p3.0.x.into(), p3.0.y.into(), p4.0.x.into(), p4.0.y.into()],
+                            ));
+                        } else if p2.0 == p3.0 {
                             // first control point coincides with final point of curve
-                            operations.push(Operation::new(OP_PATH_CONST_3BEZIER_V2, vec![p2.0.x.into(), p2.0.y.into(), p4.0.x.into(), p4.0.y.into()]));
-                        }else{
+                            operations.push(Operation::new(
+                                OP_PATH_CONST_3BEZIER_V2,
+                                vec![p2.0.x.into(), p2.0.y.into(), p4.0.x.into(), p4.0.y.into()],
+                            ));
+                        } else {
                             // regular bezier curve with four points
-                            operations.push(Operation::new(OP_PATH_CONST_4BEZIER, vec![p2.0.x.into(), p2.0.y.into(), p3.0.x.into(), p3.0.y.into(), p4.0.x.into(), p4.0.y.into()]));
+                            operations.push(Operation::new(
+                                OP_PATH_CONST_4BEZIER,
+                                vec![
+                                    p2.0.x.into(),
+                                    p2.0.y.into(),
+                                    p3.0.x.into(),
+                                    p3.0.y.into(),
+                                    p4.0.x.into(),
+                                    p4.0.y.into(),
+                                ],
+                            ));
                         }
                         current += 3;
                         continue;
@@ -117,7 +123,10 @@ impl Line {
             }
 
             // normal straight line
-            operations.push(Operation::new(OP_PATH_CONST_LINE_TO, vec![p2.0.x.into(), p2.0.y.into()]));
+            operations.push(Operation::new(
+                OP_PATH_CONST_LINE_TO,
+                vec![p2.0.x.into(), p2.0.y.into()],
+            ));
             current += 1;
         }
 

--- a/src/ocg.rs
+++ b/src/ocg.rs
@@ -1,4 +1,4 @@
-extern crate lopdf;
+use lopdf;
 
 #[derive(Default, Debug, Clone)]
 pub struct OCGList {
@@ -9,16 +9,12 @@ pub struct OCGList {
 
 impl OCGList {
     /// Creates a new OCG list
-    pub fn new()
-    -> Self
-    {
+    pub fn new() -> Self {
         Self::default()
     }
 
     /// Adds a new OCG List from a reference
-    pub fn add_ocg(&mut self, obj: lopdf::Object)
-    -> OCGRef
-    {
+    pub fn add_ocg(&mut self, obj: lopdf::Object) -> OCGRef {
         let len = self.layers.len();
         let ocg_ref = OCGRef::new(len);
         self.layers.push((ocg_ref.clone(), obj));
@@ -26,18 +22,15 @@ impl OCGList {
     }
 }
 
-impl Into<lopdf::Dictionary> for OCGList {
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_return))]
-    fn into(self)
-    -> lopdf::Dictionary
-    {
+impl From<OCGList> for lopdf::Dictionary {
+    fn from(val: OCGList) -> Self {
         let mut dict = lopdf::Dictionary::new();
 
-        for entry in self.layers {
+        for entry in val.layers {
             dict.set(entry.0.name, entry.1);
         }
 
-        return dict;
+        dict
     }
 }
 
@@ -49,11 +42,9 @@ pub struct OCGRef {
 
 impl OCGRef {
     /// Creates a new OCG reference from an index
-    pub fn new(index: usize)
-    -> Self
-    {
+    pub fn new(index: usize) -> Self {
         Self {
-            name: format!("MC{}", index),
+            name: format!("MC{index}"),
         }
     }
 }

--- a/src/pattern.rs
+++ b/src/pattern.rs
@@ -3,15 +3,11 @@ use std::collections::HashMap;
 
 /// __STUB__
 #[derive(Default, Debug, Copy, Clone)]
-pub struct Pattern {
-
-}
+pub struct Pattern {}
 
 impl Pattern {
     /// Creates a new Pattern
-    pub fn new()
-    -> Self
-    {
+    pub fn new() -> Self {
         Self::default()
     }
 }
@@ -23,11 +19,9 @@ pub struct PatternRef {
 }
 
 impl PatternRef {
-    pub fn new(index: usize)
-    -> Self
-    {
+    pub fn new(index: usize) -> Self {
         Self {
-            name: format!("PT{}", index),
+            name: format!("PT{index}"),
         }
     }
 }
@@ -39,18 +33,14 @@ pub struct PatternList {
 
 impl PatternList {
     /// Creates a new pattern list
-    pub fn new()
-    -> Self
-    {
+    pub fn new() -> Self {
         Self {
             patterns: HashMap::new(),
         }
     }
 
     /// Adds a new pattern to the pattern list
-    pub fn add_pattern(&mut self, pattern: Pattern)
-    -> PatternRef
-    {
+    pub fn add_pattern(&mut self, pattern: Pattern) -> PatternRef {
         let len = self.patterns.len();
         let pattern_ref = PatternRef::new(len);
         self.patterns.insert(pattern_ref.name.clone(), pattern);
@@ -58,10 +48,8 @@ impl PatternList {
     }
 }
 
-impl Into<lopdf::Dictionary> for PatternList {
-    fn into(self)
-    -> lopdf::Dictionary
-    {
+impl From<PatternList> for lopdf::Dictionary {
+    fn from(_val: PatternList) -> Self {
         // todo
         lopdf::Dictionary::new()
     }

--- a/src/pdf_conformance.rs
+++ b/src/pdf_conformance.rs
@@ -72,12 +72,12 @@ impl Default for PdfConformance {
     }
 }
 
-/// Allows building custom conformance profiles. This is useful if you want very small documents for example and 
+/// Allows building custom conformance profiles. This is useful if you want very small documents for example and
 /// you don't __need__ conformance with any PDF standard, you just want a PDF file.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct CustomPdfConformance {
     /// Identifier for this conformance
-    /// 
+    ///
     /// Default: __""__
     pub identifier: String,
     /// Does this standard allow 3d content?
@@ -101,21 +101,21 @@ pub struct CustomPdfConformance {
     /// Default: __true__
     pub allows_jpeg_content: bool,
     /// Does this standard require XMP metadata to be set?
-    /// 
+    ///
     /// Default: __true__
     pub requires_xmp_metadata: bool,
     /// Does this standard allow the default PDF fonts (Helvetica, etc.)
-    /// 
+    ///
     /// _(please don't enable this if you do any work that has to be printed accurately)_
-    /// 
+    ///
     /// Default: __false__
     pub allows_default_fonts: bool,
     /// Does this standard require an ICC profile to be embedded for color management?
-    /// 
+    ///
     /// Default: __true__
     pub requires_icc_profile: bool,
     /// Does this standard allow PDF layers?
-    /// 
+    ///
     /// Default: __true__
     pub allows_pdf_layers: bool,
 }
@@ -138,33 +138,30 @@ impl Default for CustomPdfConformance {
 }
 
 impl PdfConformance {
-
     /// Get the identifier string for PDF
-    pub fn get_identifier_string(&self)
-    -> String
-    {
+    pub fn get_identifier_string(&self) -> String {
         // todo: these identifiers might not be correct in all cases
         let identifier = match *self {
-            PdfConformance::A1B_2005_PDF_1_4  => "PDF/A-1b:2005",
-            PdfConformance::A1A_2005_PDF_1_4  => "PDF/A-1a:2005",
-            PdfConformance::A2_2011_PDF_1_7   => "PDF/A-2:2011",
-            PdfConformance::A2A_2011_PDF_1_7  => "PDF/A-2a:2011",
-            PdfConformance::A2B_2011_PDF_1_7  => "PDF/A-2b:2011",
-            PdfConformance::A2U_2011_PDF_1_7  => "PDF/A-2u:2011",
-            PdfConformance::A3_2012_PDF_1_7   => "PDF/A-3:2012",
-            PdfConformance::UA_2014_PDF_1_6   => "PDF/UA",
-            PdfConformance::X1A_2001_PDF_1_3  => "PDF/X-1a:2001",
-            PdfConformance::X3_2002_PDF_1_3   => "PDF/X-3:2002",
-            PdfConformance::X1A_2003_PDF_1_4  => "PDF/X-1a:2003",
-            PdfConformance::X3_2003_PDF_1_4   => "PDF/X-3:2003",
-            PdfConformance::X4_2010_PDF_1_4   => "PDF/X-4",
-            PdfConformance::X4P_2010_PDF_1_6  => "PDF/X-4P",
-            PdfConformance::X5G_2010_PDF_1_6  => "PDF/X-5G",
+            PdfConformance::A1B_2005_PDF_1_4 => "PDF/A-1b:2005",
+            PdfConformance::A1A_2005_PDF_1_4 => "PDF/A-1a:2005",
+            PdfConformance::A2_2011_PDF_1_7 => "PDF/A-2:2011",
+            PdfConformance::A2A_2011_PDF_1_7 => "PDF/A-2a:2011",
+            PdfConformance::A2B_2011_PDF_1_7 => "PDF/A-2b:2011",
+            PdfConformance::A2U_2011_PDF_1_7 => "PDF/A-2u:2011",
+            PdfConformance::A3_2012_PDF_1_7 => "PDF/A-3:2012",
+            PdfConformance::UA_2014_PDF_1_6 => "PDF/UA",
+            PdfConformance::X1A_2001_PDF_1_3 => "PDF/X-1a:2001",
+            PdfConformance::X3_2002_PDF_1_3 => "PDF/X-3:2002",
+            PdfConformance::X1A_2003_PDF_1_4 => "PDF/X-1a:2003",
+            PdfConformance::X3_2003_PDF_1_4 => "PDF/X-3:2003",
+            PdfConformance::X4_2010_PDF_1_4 => "PDF/X-4",
+            PdfConformance::X4P_2010_PDF_1_6 => "PDF/X-4P",
+            PdfConformance::X5G_2010_PDF_1_6 => "PDF/X-5G",
             PdfConformance::X5PG_2010_PDF_1_6 => "PDF/X-5PG",
-            PdfConformance::X5N_2010_PDF_1_6  => "PDF/X-5N",
-            PdfConformance::E1_2008_PDF_1_6   => "PDF/E-1",
-            PdfConformance::VT_2010_PDF_1_4   => "PDF/VT",
-            PdfConformance::Custom(ref c)     => &c.identifier,
+            PdfConformance::X5N_2010_PDF_1_6 => "PDF/X-5N",
+            PdfConformance::E1_2008_PDF_1_6 => "PDF/E-1",
+            PdfConformance::VT_2010_PDF_1_4 => "PDF/VT",
+            PdfConformance::Custom(ref c) => &c.identifier,
         };
 
         identifier.to_string()
@@ -172,108 +169,90 @@ impl PdfConformance {
 
     /// __STUB__: Detects if the PDF has 3D content, but the
     /// conformance to the given PDF standard does not allow it.
-    pub fn is_3d_content_allowed(&self)
-    -> bool
-    {
+    pub fn is_3d_content_allowed(&self) -> bool {
         match *self {
-           PdfConformance::E1_2008_PDF_1_6   => true,
-           PdfConformance::Custom(ref c)     => c.allows_3d_content,
-           _ => false,
+            PdfConformance::E1_2008_PDF_1_6 => true,
+            PdfConformance::Custom(ref c) => c.allows_3d_content,
+            _ => false,
         }
     }
 
     /// Does this conformance level allow video
-    pub fn is_video_content_allowed(&self)
-    -> bool
-    {
+    pub fn is_video_content_allowed(&self) -> bool {
         // todo
         match *self {
             PdfConformance::Custom(ref c) => c.allows_video_content,
-            _                             => false,
+            _ => false,
         }
     }
 
     /// __STUB__: Detects if the PDF has audio content, but the
     /// conformance to the given PDF standard does not allow it.
-    pub fn is_audio_content_allowed(&self)
-    -> bool
-    {
+    pub fn is_audio_content_allowed(&self) -> bool {
         // todo
         match *self {
             PdfConformance::Custom(ref c) => c.allows_audio_content,
-            _                             => false,
+            _ => false,
         }
     }
 
     /// __STUB__: Detects if the PDF has 3D content, but the
     /// conformance to the given PDF standard does not allow it.
-    pub fn is_javascript_content_allowed(&self)
-    -> bool
-    {
+    pub fn is_javascript_content_allowed(&self) -> bool {
         // todo
         match *self {
             PdfConformance::Custom(ref c) => c.allows_embedded_javascript,
-            _                         => false,
+            _ => false,
         }
     }
 
     /// __STUB__: Detects if the PDF has JPEG images, but the
     /// conformance to the given PDF standard does not allow it
-    pub fn is_jpeg_content_allowed(&self)
-    -> bool
-    {
+    pub fn is_jpeg_content_allowed(&self) -> bool {
         // todo
         match *self {
             PdfConformance::Custom(ref c) => c.allows_jpeg_content,
-            _                         => true,
+            _ => true,
         }
     }
 
     /// Detects if the PDF must have XMP metadata
     /// if it has to conform to the given PDF Standard
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
-    pub fn must_have_xmp_metadata(&self)
-    -> bool
-    {
+    pub fn must_have_xmp_metadata(&self) -> bool {
         match *self {
-            PdfConformance::X1A_2001_PDF_1_3  => { true },
-            PdfConformance::X3_2002_PDF_1_3   => { true },
-            PdfConformance::X1A_2003_PDF_1_4  => { true },
-            PdfConformance::X3_2003_PDF_1_4   => { true },
-            PdfConformance::X4_2010_PDF_1_4   => { true },
-            PdfConformance::X4P_2010_PDF_1_6  => { true },
-            PdfConformance::X5G_2010_PDF_1_6  => { true },
-            PdfConformance::X5PG_2010_PDF_1_6 => { true },
-            PdfConformance::Custom(ref c)     => { c.requires_xmp_metadata }
-            _                                 => { false },
+            PdfConformance::X1A_2001_PDF_1_3 => true,
+            PdfConformance::X3_2002_PDF_1_3 => true,
+            PdfConformance::X1A_2003_PDF_1_4 => true,
+            PdfConformance::X3_2003_PDF_1_4 => true,
+            PdfConformance::X4_2010_PDF_1_4 => true,
+            PdfConformance::X4P_2010_PDF_1_6 => true,
+            PdfConformance::X5G_2010_PDF_1_6 => true,
+            PdfConformance::X5PG_2010_PDF_1_6 => true,
+            PdfConformance::Custom(ref c) => c.requires_xmp_metadata,
+            _ => false,
         }
     }
 
     /// Check if the conformance level must have an ICC Profile
-    pub fn must_have_icc_profile(&self)
-    -> bool
-    {
+    pub fn must_have_icc_profile(&self) -> bool {
         // todo
         match *self {
-            PdfConformance::X1A_2001_PDF_1_3  => { false },
-            PdfConformance::Custom(ref c)     => { c.requires_icc_profile }
-            _                                 => { true },
+            PdfConformance::X1A_2001_PDF_1_3 => false,
+            PdfConformance::Custom(ref c) => c.requires_icc_profile,
+            _ => true,
         }
     }
 
     /// __STUB__: Detects if the PDF has layering (optional content groups),
     /// but the conformance to the given PDF standard does not allow it.
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
-    pub fn is_layering_allowed(&self)
-    -> bool
-    {
-        match *self {
-            PdfConformance::X1A_2001_PDF_1_3  => { false },
-            PdfConformance::X3_2002_PDF_1_3   => { false },
-            PdfConformance::X1A_2003_PDF_1_4  => { false },
-            PdfConformance::X3_2003_PDF_1_4   => { false },
-            PdfConformance::Custom(ref c)     => { c.allows_pdf_layers }
-            _                                 => { true },
+    pub fn is_layering_allowed(&self) -> bool {
+        match self {
+            PdfConformance::X1A_2001_PDF_1_3 => false,
+            PdfConformance::X3_2002_PDF_1_3 => false,
+            PdfConformance::X1A_2003_PDF_1_4 => false,
+            PdfConformance::X3_2003_PDF_1_4 => false,
+            PdfConformance::Custom(c) => c.allows_pdf_layers,
+            _ => true,
         }
     }
 }

--- a/src/pdf_layer.rs
+++ b/src/pdf_layer.rs
@@ -1,14 +1,15 @@
 //! PDF layer management. Layers can contain referenced or real content.
 
-use indices::{PdfPageIndex, PdfLayerIndex};
-use std::rc::Weak;
-use std::cell::RefCell;
-use lopdf::content::Operation;
-use glob_defines::OP_PATH_STATE_SET_LINE_WIDTH;
-use {
-    Font, XObject, PdfColor,  PdfDocument, ExtendedGraphicsStateBuilder, Line, ImageXObject, XObjectRef, Color, IndirectFontRef, BlendMode,
-    LineJoinStyle, LineCapStyle, LineDashPattern, CurTransMat, TextMatrix, TextRenderingMode, Mm, Pt
+use crate::glob_defines::OP_PATH_STATE_SET_LINE_WIDTH;
+use crate::indices::{PdfLayerIndex, PdfPageIndex};
+use crate::{
+    BlendMode, Color, CurTransMat, ExtendedGraphicsStateBuilder, Font, ImageXObject,
+    IndirectFontRef, Line, LineCapStyle, LineDashPattern, LineJoinStyle, Mm, PdfColor, PdfDocument,
+    Pt, TextMatrix, TextRenderingMode, XObject, XObjectRef,
 };
+use lopdf::content::Operation;
+use std::cell::RefCell;
+use std::rc::Weak;
 
 /// One layer of PDF data
 #[derive(Debug, Clone)]
@@ -32,11 +33,11 @@ pub struct PdfLayerReference {
 }
 
 impl PdfLayer {
-
     /// Create a new layer, with a name and what index the layer has in the page
     #[inline]
-    pub fn new<S>(name: S)
-    -> Self where S: Into<String>
+    pub fn new<S>(name: S) -> Self
+    where
+        S: Into<String>,
     {
         Self {
             name: name.into(),
@@ -45,12 +46,12 @@ impl PdfLayer {
     }
 }
 
-impl Into<lopdf::Stream> for PdfLayer {
-    fn into(self)
-    -> lopdf::Stream
-    {
-        use lopdf::{Stream, Dictionary};
-        let stream_content = lopdf::content::Content { operations: self.operations };
+impl From<PdfLayer> for lopdf::Stream {
+    fn from(val: PdfLayer) -> Self {
+        use lopdf::{Dictionary, Stream};
+        let stream_content = lopdf::content::Content {
+            operations: val.operations,
+        };
 
         // page contents may not be compressed (todo: is this valid for XObjects?)
         Stream::new(Dictionary::new(), stream_content.encode().unwrap()).with_compression(false)
@@ -58,11 +59,9 @@ impl Into<lopdf::Stream> for PdfLayer {
 }
 
 impl PdfLayerReference {
-
     /// Add a shape to the layer. Use `closed` to indicate whether the line is a closed line
     /// Use has_fill to determine if the line should be filled.
-    pub fn add_shape(&self, line: Line)
-    {
+    pub fn add_shape(&self, line: Line) {
         let line_ops = line.into_stream_op();
         for op in line_ops {
             self.add_operation(op);
@@ -71,8 +70,9 @@ impl PdfLayerReference {
 
     /// Add an image to the layer. To be called from the
     /// `image.add_to_layer()` class (see `use_xobject` documentation)
-    pub(crate) fn add_image<T>(&self, image: T)
-    -> XObjectRef where T: Into<ImageXObject>
+    pub(crate) fn add_image<T>(&self, image: T) -> XObjectRef
+    where
+        T: Into<ImageXObject>,
     {
         self.add_xobject(image.into())
     }
@@ -80,8 +80,9 @@ impl PdfLayerReference {
     /// Adds a general XObject to the layer, similar to `add_image`,
     /// but allows for other types of XObjects to be added to the
     /// page, not just images
-    pub(crate) fn add_xobject<T>(&self, xobject: T)
-    -> XObjectRef where T: Into<XObject>
+    pub(crate) fn add_xobject<T>(&self, xobject: T) -> XObjectRef
+    where
+        T: Into<XObject>,
     {
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
@@ -93,44 +94,36 @@ impl PdfLayerReference {
     /// Begins a new text section
     /// You have to make sure to call `end_text_section` afterwards
     #[inline]
-    pub fn begin_text_section(&self)
-    -> ()
-    {
-        self.add_operation(Operation::new("BT", vec![] ));
+    pub fn begin_text_section(&self) {
+        self.add_operation(Operation::new("BT", vec![]));
     }
 
     /// Ends a new text section
     /// Only valid if `begin_text_section` has been called
     #[inline]
-    pub fn end_text_section(&self)
-    -> ()
-    {
-        self.add_operation(Operation::new("ET", vec![] ));
+    pub fn end_text_section(&self) {
+        self.add_operation(Operation::new("ET", vec![]));
     }
 
     /// Set the current fill color for the layer
     #[inline]
-    pub fn set_fill_color(&self, fill_color: Color)
-    -> ()
-    {
+    pub fn set_fill_color(&self, fill_color: Color) {
         self.add_operation(PdfColor::FillColor(fill_color));
     }
 
     /// Set the current font, only valid in a `begin_text_section` to
     /// `end_text_section` block
     #[inline]
-    pub fn set_font(&self, font: &IndirectFontRef, font_size: f64)
-    -> ()
-    {
-        self.add_operation(Operation::new("Tf",
-            vec![font.name.clone().into(), (font_size).into()]
+    pub fn set_font(&self, font: &IndirectFontRef, font_size: f64) {
+        self.add_operation(Operation::new(
+            "Tf",
+            vec![font.name.clone().into(), (font_size).into()],
         ));
     }
 
     /// Set the current line / outline color for the layer
     #[inline]
-    pub fn set_outline_color(&self, color: Color)
-    {
+    pub fn set_outline_color(&self, color: Color) {
         self.add_operation(PdfColor::OutlineColor(color));
     }
     /// Instantiate layers, forms and postscript items on the page
@@ -146,10 +139,10 @@ impl PdfLayerReference {
         self.save_graphics_state();
 
         // do transformations to XObject
-        if transformations.len() > 0 {
+        if !transformations.is_empty() {
             let mut t = CurTransMat::Identity;
             for q in transformations {
-                t = CurTransMat::Raw(CurTransMat::combine_matrix(t.into(), q.clone().into()));
+                t = CurTransMat::Raw(CurTransMat::combine_matrix(t.into(), (*q).into()));
             }
             self.add_operation(t);
         }
@@ -162,11 +155,10 @@ impl PdfLayerReference {
     }
 
     /// Set the overprint mode of the stroke color to true (overprint) or false (no overprint)
-    pub fn set_overprint_fill(&self, overprint: bool)
-    {
+    pub fn set_overprint_fill(&self, overprint: bool) {
         let new_overprint_state = ExtendedGraphicsStateBuilder::new()
-                                      .with_overprint_fill(overprint)
-                                      .build();
+            .with_overprint_fill(overprint)
+            .build();
 
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
@@ -176,19 +168,20 @@ impl PdfLayerReference {
 
         // add gs operator to stream
         page_mut.layers[self.layer.0]
-            .operations.push(lopdf::content::Operation::new(
-                "gs", vec![lopdf::Object::Name(new_ref.gs_name.as_bytes().to_vec())]
-        ));
+            .operations
+            .push(lopdf::content::Operation::new(
+                "gs",
+                vec![lopdf::Object::Name(new_ref.gs_name.as_bytes().to_vec())],
+            ));
     }
 
     /// Set the overprint mode of the fill color to true (overprint) or false (no overprint)
     /// This changes the graphics state of the current page, don't do it too often or you'll bloat the file size
-    pub fn set_overprint_stroke(&self, overprint: bool)
-    {
+    pub fn set_overprint_stroke(&self, overprint: bool) {
         // this is technically an operation on the page level
         let new_overprint_state = ExtendedGraphicsStateBuilder::new()
-                                      .with_overprint_stroke(overprint)
-                                      .build();
+            .with_overprint_stroke(overprint)
+            .build();
 
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
@@ -196,19 +189,20 @@ impl PdfLayerReference {
 
         let new_ref = page_mut.add_graphics_state(new_overprint_state);
         page_mut.layers[self.layer.0]
-            .operations.push(lopdf::content::Operation::new(
-                "gs", vec![lopdf::Object::Name(new_ref.gs_name.as_bytes().to_vec())]
-        ));
+            .operations
+            .push(lopdf::content::Operation::new(
+                "gs",
+                vec![lopdf::Object::Name(new_ref.gs_name.as_bytes().to_vec())],
+            ));
     }
 
     /// Set the overprint mode of the fill color to true (overprint) or false (no overprint)
     /// This changes the graphics state of the current page, don't do it too often or you'll bloat the file size
-    pub fn set_blend_mode(&self, blend_mode: BlendMode)
-    {
+    pub fn set_blend_mode(&self, blend_mode: BlendMode) {
         // this is technically an operation on the page level
         let new_blend_mode_state = ExtendedGraphicsStateBuilder::new()
-                                      .with_blend_mode(blend_mode)
-                                      .build();
+            .with_blend_mode(blend_mode)
+            .build();
 
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
@@ -217,9 +211,11 @@ impl PdfLayerReference {
         let new_ref = page_mut.add_graphics_state(new_blend_mode_state);
 
         page_mut.layers[self.layer.0]
-            .operations.push(lopdf::content::Operation::new(
-                "gs", vec![lopdf::Object::Name(new_ref.gs_name.as_bytes().to_vec())]
-        ));
+            .operations
+            .push(lopdf::content::Operation::new(
+                "gs",
+                vec![lopdf::Object::Name(new_ref.gs_name.as_bytes().to_vec())],
+            ));
     }
 
     /// Set the current line thickness, in points
@@ -227,10 +223,12 @@ impl PdfLayerReference {
     /// __NOTE__: 0.0 is a special value, it does not make the line disappear, but rather
     /// makes it appear 1px wide across all devices
     #[inline]
-    pub fn set_outline_thickness(&self, outline_thickness: f64)
-    {
+    pub fn set_outline_thickness(&self, outline_thickness: f64) {
         use lopdf::Object::*;
-        self.add_operation(Operation::new(OP_PATH_STATE_SET_LINE_WIDTH, vec![Real(outline_thickness)]));
+        self.add_operation(Operation::new(
+            OP_PATH_STATE_SET_LINE_WIDTH,
+            vec![Real(outline_thickness)],
+        ));
     }
 
     /// Set the current line join style for outlines
@@ -271,12 +269,10 @@ impl PdfLayerReference {
 
     /// Sets the position where the text should appear
     #[inline]
-    pub fn set_text_cursor(&self, x:Mm, y:Mm) {
+    pub fn set_text_cursor(&self, x: Mm, y: Mm) {
         let x_in_pt: Pt = x.into();
         let y_in_pt: Pt = y.into();
-        self.add_operation(Operation::new("Td",
-                vec![x_in_pt.into(), y_in_pt.into()]
-        ));
+        self.add_operation(Operation::new("Td", vec![x_in_pt.into(), y_in_pt.into()]));
     }
 
     /// If called inside a text block scoped by `begin_text_section` and
@@ -292,9 +288,7 @@ impl PdfLayerReference {
     /// (must be called within `begin_text_block` and `end_text_block`)
     #[inline]
     pub fn set_line_height(&self, height: f64) {
-        self.add_operation(Operation::new("TL",
-            vec![lopdf::Object::Real(height)]
-        ));
+        self.add_operation(Operation::new("TL", vec![lopdf::Object::Real(height)]));
     }
 
     /// Sets the character spacing inside a text block
@@ -302,9 +296,7 @@ impl PdfLayerReference {
     /// the spacing inside a word by 3pt.
     #[inline]
     pub fn set_character_spacing(&self, spacing: f64) {
-        self.add_operation(Operation::new("Tc",
-            vec![lopdf::Object::Real(spacing)]
-        ));
+        self.add_operation(Operation::new("Tc", vec![lopdf::Object::Real(spacing)]));
     }
 
     /// Sets the word spacing inside a text block.
@@ -317,9 +309,7 @@ impl PdfLayerReference {
     /// with builtin fonts.
     #[inline]
     pub fn set_word_spacing(&self, spacing: f64) {
-        self.add_operation(Operation::new("Tw",
-            vec![lopdf::Object::Real(spacing)]
-        ));
+        self.add_operation(Operation::new("Tw", vec![lopdf::Object::Real(spacing)]));
     }
 
     /// Sets the horizontal scaling (like a "condensed" font)
@@ -328,9 +318,7 @@ impl PdfLayerReference {
     /// but stretch the text
     #[inline]
     pub fn set_text_scaling(&self, scaling: f64) {
-        self.add_operation(Operation::new("Tz",
-            vec![lopdf::Object::Real(scaling)]
-        ));
+        self.add_operation(Operation::new("Tz", vec![lopdf::Object::Real(scaling)]));
     }
 
     /// Offsets the current text positon (used for superscript
@@ -340,22 +328,22 @@ impl PdfLayerReference {
     /// change the size of the font
     #[inline]
     pub fn set_line_offset(&self, offset: f64) {
-        self.add_operation(Operation::new("Ts",
-            vec![lopdf::Object::Real(offset)]
-        ));
+        self.add_operation(Operation::new("Ts", vec![lopdf::Object::Real(offset)]));
     }
 
     #[inline]
     pub fn set_text_rendering_mode(&self, mode: TextRenderingMode) {
-        self.add_operation(Operation::new("Tr",
-            vec![lopdf::Object::Integer(mode.into())]
+        self.add_operation(Operation::new(
+            "Tr",
+            vec![lopdf::Object::Integer(mode.into())],
         ));
     }
 
     /// Add text to the file at the current position by specifying font codepoints for an
     /// ExternalFont
     pub fn write_codepoints<I>(&self, codepoints: I)
-    where I: IntoIterator<Item = u16>
+    where
+        I: IntoIterator<Item = u16>,
     {
         use lopdf::Object::*;
         use lopdf::StringFormat::Hexadecimal;
@@ -370,17 +358,16 @@ impl PdfLayerReference {
 
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
-        doc.pages[self.page.0]
-            .layers[self.layer.0]
-                .operations.push(Operation::new("Tj",
-                    vec![String(bytes, Hexadecimal)]
-            ));
+        doc.pages[self.page.0].layers[self.layer.0]
+            .operations
+            .push(Operation::new("Tj", vec![String(bytes, Hexadecimal)]));
     }
 
     /// Add text to the file at the current position by specifying
     /// font codepoints with additional kerning offset
     pub fn write_positioned_codepoints<I>(&self, codepoints: I)
-    where I: IntoIterator<Item = (i64, u16)>
+    where
+        I: IntoIterator<Item = (i64, u16)>,
     {
         use lopdf::Object::*;
         use lopdf::StringFormat::Hexadecimal;
@@ -397,9 +384,9 @@ impl PdfLayerReference {
 
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
-        doc.pages[self.page.0]
-            .layers[self.layer.0]
-                .operations.push(Operation::new("TJ", vec![Array(list)]));
+        doc.pages[self.page.0].layers[self.layer.0]
+            .operations
+            .push(Operation::new("TJ", vec![Array(list)]));
     }
 
     /// Add text to the file at the current position
@@ -410,7 +397,8 @@ impl PdfLayerReference {
     /// [Windows-1252]: https://en.wikipedia.org/wiki/Windows-1252
     #[inline]
     pub fn write_text<S>(&self, text: S, font: &IndirectFontRef)
-    -> () where S: Into<String>
+    where
+        S: Into<String>,
     {
         // NOTE: The unwrap() calls in this function are safe, since
         // we've already checked the font for validity when it was added to the document
@@ -432,7 +420,6 @@ impl PdfLayerReference {
 
         let bytes: Vec<u8> = {
             if let Font::ExternalFont(face_direct_ref) = doc.fonts.get_font(font).unwrap().data {
-
                 let mut list_gid = Vec::<u16>::new();
                 let font = &face_direct_ref.font_data;
 
@@ -442,8 +429,9 @@ impl PdfLayerReference {
                     }
                 }
 
-                list_gid.iter()
-                    .flat_map(|x| vec!((x >> 8) as u8, (x & 255) as u8))
+                list_gid
+                    .iter()
+                    .flat_map(|x| vec![(x >> 8) as u8, (x & 255) as u8])
                     .collect::<Vec<u8>>()
             } else {
                 // For built-in fonts, we selected the WinAnsiEncoding, see the Into<LoDictionary>
@@ -452,11 +440,9 @@ impl PdfLayerReference {
             }
         };
 
-        doc.pages[self.page.0]
-            .layers[self.layer.0]
-                .operations.push(Operation::new("Tj",
-                    vec![String(bytes, Hexadecimal)]
-        ));
+        doc.pages[self.page.0].layers[self.layer.0]
+            .operations
+            .push(Operation::new("Tj", vec![String(bytes, Hexadecimal)]));
     }
 
     /// Saves the current graphic state
@@ -478,15 +464,15 @@ impl PdfLayerReference {
     ///
     /// [Windows-1252]: https://en.wikipedia.org/wiki/Windows-1252
     #[inline]
-    pub fn use_text<S>(&self, text: S, font_size: f64,
-                       x: Mm, y: Mm, font: &IndirectFontRef)
-    -> () where S: Into<String>
+    pub fn use_text<S>(&self, text: S, font_size: f64, x: Mm, y: Mm, font: &IndirectFontRef)
+    where
+        S: Into<String>,
     {
-            self.begin_text_section();
-            self.set_font(font, font_size);
-            self.set_text_cursor(x, y);
-            self.write_text(text, font);
-            self.end_text_section();
+        self.begin_text_section();
+        self.set_font(font, font_size);
+        self.set_text_cursor(x, y);
+        self.write_text(text, font);
+        self.end_text_section();
     }
 
     /// Add an operation
@@ -495,7 +481,8 @@ impl PdfLayerReference {
     /// Notice that [Operation](crate::lopdf::content::Operation) is part of the
     /// `lopdf` crate, which is re-exported by this crate.
     pub fn add_operation<T>(&self, op: T)
-    -> () where T: Into<Operation>
+    where
+        T: Into<Operation>,
     {
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
@@ -503,39 +490,40 @@ impl PdfLayerReference {
         layer.operations.push(op.into());
     }
 
-/*
-    /// Instantiate SVG data
-    #[inline]
-    pub fn use_svg(&self, width_mm: f64, height_mm: f64,
-                   x_mm: f64, y_mm: f64, svg_data_index: SvgIndex)
-    {
-        let svg_element_ref = {
+    /*
+        /// Instantiate SVG data
+        #[inline]
+        pub fn use_svg(&self, width_mm: f64, height_mm: f64,
+                       x_mm: f64, y_mm: f64, svg_data_index: SvgIndex)
+        {
+            let svg_element_ref = {
+                let doc = self.document.upgrade().unwrap();
+                let doc = doc.borrow_mut();
+                let element = doc.contents.get((svg_data_index.0).0).expect("invalid svg reference");
+                (*element).clone()
+            };
+
             let doc = self.document.upgrade().unwrap();
-            let doc = doc.borrow_mut();
-            let element = doc.contents.get((svg_data_index.0).0).expect("invalid svg reference");
-            (*element).clone()
-        };
+            let mut doc = doc.borrow_mut();
 
-        let doc = self.document.upgrade().unwrap();
-        let mut doc = doc.borrow_mut();
-
-        // todo: what about width / height?
-        doc.pages.get_mut(self.page.0).unwrap()
-            .layers.get_mut(self.layer.0).unwrap()
-                .layer.push(PdfResource::ReferencedResource(svg_data_index.0.clone()));
-    }
-*/
+            // todo: what about width / height?
+            doc.pages.get_mut(self.page.0).unwrap()
+                .layers.get_mut(self.layer.0).unwrap()
+                    .layer.push(PdfResource::ReferencedResource(svg_data_index.0.clone()));
+        }
+    */
 
     // internal function to invoke an xobject
-    fn internal_invoke_xobject(&self, name: String)
-    {
+    fn internal_invoke_xobject(&self, name: String) {
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
         let page_mut = &mut doc.pages[self.page.0];
 
         page_mut.layers[self.layer.0]
-          .operations.push(lopdf::content::Operation::new(
-              "Do", vec![lopdf::Object::Name(name.as_bytes().to_vec())]
-        ));
+            .operations
+            .push(lopdf::content::Operation::new(
+                "Do",
+                vec![lopdf::Object::Name(name.as_bytes().to_vec())],
+            ));
     }
 }

--- a/src/pdf_metadata.rs
+++ b/src/pdf_metadata.rs
@@ -1,107 +1,110 @@
 //! Wapper type for shared metadata between XMP Metadata and the `DocumentInfo` dictionary
 
-use lopdf;
 use crate::OffsetDateTime;
-use {
-	IccProfileType, PdfConformance, XmpMetadata, DocumentInfo, IccProfile
-};
+use lopdf;
+use crate::{DocumentInfo, IccProfile, IccProfileType, PdfConformance, XmpMetadata};
 
-use glob_defines::ICC_PROFILE_ECI_V2;
+use crate::glob_defines::ICC_PROFILE_ECI_V2;
 
 /// This is a wrapper in order to keep shared data between the documents XMP metadata and
 /// the "Info" dictionary in sync
 #[derive(Debug, Clone)]
 pub struct PdfMetadata {
-	/// Creation date of the document
-	pub creation_date: OffsetDateTime,
-	/// Modification date of the document
-	pub modification_date: OffsetDateTime,
-	/// Creation date of the metadata
-	pub metadata_date: OffsetDateTime,
-	/// PDF document title
-	pub document_title: String,
-	/// PDF document author
-	pub author: String,
-	/// The creator of the document
-	pub creator: String,
-	/// The producer of the document
-	pub producer: String,
-	/// Keywords associated with the document
-	pub keywords: Vec<String>,
-	/// The subject of the document
-	pub subject: String,
-	/// Identifier associated with the document
-	pub identifier: String,
-	/// Is the document trapped?
-	pub trapping: bool,
-	/// PDF document version
-	pub document_version: u32,
-	/// PDF Standard
-	pub conformance: PdfConformance,
-	/// XMP Metadata. Is ignored on save if the PDF conformance does not allow XMP
-	pub xmp_metadata: XmpMetadata,
-	/// PDF Info dictionary. Contains metadata for this document
-	pub document_info: DocumentInfo,
-	/// Target color profile
-	pub target_icc_profile: Option<IccProfile>,
+    /// Creation date of the document
+    pub creation_date: OffsetDateTime,
+    /// Modification date of the document
+    pub modification_date: OffsetDateTime,
+    /// Creation date of the metadata
+    pub metadata_date: OffsetDateTime,
+    /// PDF document title
+    pub document_title: String,
+    /// PDF document author
+    pub author: String,
+    /// The creator of the document
+    pub creator: String,
+    /// The producer of the document
+    pub producer: String,
+    /// Keywords associated with the document
+    pub keywords: Vec<String>,
+    /// The subject of the document
+    pub subject: String,
+    /// Identifier associated with the document
+    pub identifier: String,
+    /// Is the document trapped?
+    pub trapping: bool,
+    /// PDF document version
+    pub document_version: u32,
+    /// PDF Standard
+    pub conformance: PdfConformance,
+    /// XMP Metadata. Is ignored on save if the PDF conformance does not allow XMP
+    pub xmp_metadata: XmpMetadata,
+    /// PDF Info dictionary. Contains metadata for this document
+    pub document_info: DocumentInfo,
+    /// Target color profile
+    pub target_icc_profile: Option<IccProfile>,
 }
 
 impl PdfMetadata {
+    /// Creates a new metadata object
+    pub fn new<S>(
+        title: S,
+        document_version: u32,
+        trapping: bool,
+        conformance: PdfConformance,
+    ) -> Self
+    where
+        S: Into<String>,
+    {
+        let current_time = OffsetDateTime::now_utc();
 
-	/// Creates a new metadata object
-	pub fn new<S>(title: S, document_version: u32, trapping: bool, conformance: PdfConformance)
-	-> Self where S: Into<String>
-	{
-		let current_time = OffsetDateTime::now_utc();
+        Self {
+            creation_date: current_time,
+            modification_date: current_time,
+            metadata_date: current_time,
+            document_title: title.into(),
+            author: String::new(),
+            creator: String::new(),
+            producer: String::new(),
+            keywords: Vec::new(),
+            subject: String::new(),
+            identifier: String::new(),
+            trapping,
+            document_version,
+            conformance,
+            xmp_metadata: XmpMetadata::new(Some("default".into()), 1),
+            document_info: DocumentInfo::new(),
+            target_icc_profile: None,
+        }
+    }
 
-		Self {
-			creation_date: current_time.clone(),
-			modification_date: current_time.clone(),
-			metadata_date: current_time.clone(),
-			document_title: title.into(),
-			author: String::new(),
-			creator: String::new(),
-			producer: String::new(),	
-			keywords: Vec::new(),
-			subject: String::new(),
-			identifier: String::new(),
-			trapping: trapping,
-			document_version: document_version,
-			conformance: conformance,
-			xmp_metadata: XmpMetadata::new(Some("default".into()), 1),
-			document_info: DocumentInfo::new(),
-			target_icc_profile: None,
-		}
-	}
+    /// Consumes the metadata, returning the (Option<xmp_metadata>, document_info, icc_profile_stream).
+    pub fn into_obj(self) -> (Option<lopdf::Object>, lopdf::Object, Option<IccProfile>) {
+        let metadata = self.clone();
+        let xmp_obj = {
+            if self.conformance.must_have_xmp_metadata() {
+                Some(self.xmp_metadata.into_obj(&metadata))
+            } else {
+                None
+            }
+        };
 
-	/// Consumes the metadata, returning the (Option<xmp_metadata>, document_info, icc_profile_stream).
-	pub fn into_obj(self)
-	-> (Option<lopdf::Object>, lopdf::Object, Option<IccProfile>)
-	{
-		let metadata = self.clone();
-		let xmp_obj = {
-			if self.conformance.must_have_xmp_metadata() {
-				Some(self.xmp_metadata.into_obj(&metadata))
-			} else {
-				None
-			}
-		};
+        let doc_info_obj = self.document_info.into_obj(&metadata);
+        // add icc profile if necessary
+        let icc_profile = {
+            if self.conformance.must_have_icc_profile() {
+                match self.target_icc_profile {
+                    Some(icc) => Some(icc),
+                    None => Some(
+                        IccProfile::new(ICC_PROFILE_ECI_V2.to_vec(), IccProfileType::Cmyk)
+                            .with_alternate_profile(false)
+                            .with_range(true),
+                    ),
+                }
+            } else {
+                None
+            }
+        };
 
-		let doc_info_obj = self.document_info.into_obj(&metadata);
-		// add icc profile if necessary
-		let icc_profile = {
-		    if self.conformance.must_have_icc_profile() {
-		        match self.target_icc_profile {
-		            Some(icc) => Some(icc),
-		            None =>      Some(IccProfile::new(ICC_PROFILE_ECI_V2.to_vec(), IccProfileType::Cmyk)
-		            			      .with_alternate_profile(false)
-		            			      .with_range(true)),
-		        }
-		    } else {
-		        None
-		    }
-		};
-
-		(xmp_obj, doc_info_obj, icc_profile)
-	}
+        (xmp_obj, doc_info_obj, icc_profile)
+    }
 }

--- a/src/pdf_page.rs
+++ b/src/pdf_page.rs
@@ -1,13 +1,13 @@
 //! PDF page management
 
 use lopdf;
-use std::rc::Weak;
 use std::cell::RefCell;
+use std::rc::Weak;
 
-use indices::{PdfPageIndex, PdfLayerIndex};
-use {
-    PdfResources, PdfLayer, PdfDocument, ExtendedGraphicsState, ExtendedGraphicsStateRef, Pattern, XObject, XObjectRef,
-    PdfLayerReference, PatternRef, Mm, Pt
+use crate::indices::{PdfLayerIndex, PdfPageIndex};
+use crate::{
+    ExtendedGraphicsState, ExtendedGraphicsStateRef, Mm, Pattern, PatternRef, PdfDocument,
+    PdfLayer, PdfLayerReference, PdfResources, Pt, XObject, XObjectRef,
 };
 
 /// PDF page
@@ -35,15 +35,12 @@ pub struct PdfPageReference {
 }
 
 impl PdfPage {
-
     /// Create a new page, notice that width / height are in millimeter.
     /// Page must contain at least one layer
     #[inline]
-    pub fn new<S>(width: Mm,
-                  height: Mm,
-                  layer_name: S,
-                  page_index: usize)
-    -> (Self, PdfLayerIndex) where S: Into<String>
+    pub fn new<S>(width: Mm, height: Mm, layer_name: S, page_index: usize) -> (Self, PdfLayerIndex)
+    where
+        S: Into<String>,
     {
         let mut page = Self {
             index: page_index,
@@ -73,11 +70,15 @@ impl PdfPage {
     /// to the document on a document level, it should contain the indices of the layers
     /// (they will be ignored, todo) and references to the actual OCG dictionaries
     #[inline]
-    pub(crate) fn collect_resources_and_streams(self, doc: &mut lopdf::Document, layers: &[(usize, lopdf::Object)])
-    -> (lopdf::Dictionary, Vec<lopdf::Stream>)
-    {
+    pub(crate) fn collect_resources_and_streams(
+        self,
+        doc: &mut lopdf::Document,
+        layers: &[(usize, lopdf::Object)],
+    ) -> (lopdf::Dictionary, Vec<lopdf::Stream>) {
         let cur_layers = layers.iter().map(|l| l.1.clone()).collect();
-        let (resource_dictionary, ocg_refs) = self.resources.into_with_document_and_layers(doc, cur_layers);
+        let (resource_dictionary, ocg_refs) = self
+            .resources
+            .into_with_document_and_layers(doc, cur_layers);
 
         // set contents
         let mut layer_streams = Vec::<lopdf::Stream>::new();
@@ -85,17 +86,21 @@ impl PdfPage {
         use lopdf::Object::*;
 
         for (idx, mut layer) in self.layers.into_iter().enumerate() {
-
             // push OCG and q to the beginning of the layer
-            layer.operations.insert(0, Operation::new("q".into(), vec![]));
-            layer.operations.insert(0, Operation::new("BDC".into(), vec![
-                Name("OC".into()),
-                Name(ocg_refs[idx].name.clone().into())
-            ]));
+            layer
+                .operations
+                .insert(0, Operation::new("q", vec![]));
+            layer.operations.insert(
+                0,
+                Operation::new(
+                    "BDC",
+                    vec![Name("OC".into()), Name(ocg_refs[idx].name.clone().into())],
+                ),
+            );
 
             // push OCG END and Q to the end of the layer stream
-            layer.operations.push(Operation::new("Q".into(), vec![]));
-            layer.operations.push(Operation::new("EMC".into(), vec![]));
+            layer.operations.push(Operation::new("Q", vec![]));
+            layer.operations.push(Operation::new("EMC", vec![]));
 
             // should end up looking like this:
 
@@ -119,36 +124,33 @@ impl PdfPage {
     /// Returns the old graphics state, in case it was overwritten, as well as a reference
     /// to the currently active graphics state
     #[inline]
-    pub fn add_graphics_state(&mut self, added_state: ExtendedGraphicsState)
-    -> ExtendedGraphicsStateRef
-    {
+    pub fn add_graphics_state(
+        &mut self,
+        added_state: ExtendedGraphicsState,
+    ) -> ExtendedGraphicsStateRef {
         self.resources.add_graphics_state(added_state)
     }
 
     /// __STUB__: Adds a pattern to the pages resources
     #[inline]
-    pub fn add_pattern(&mut self, pattern: Pattern)
-    -> PatternRef
-    {
+    pub fn add_pattern(&mut self, pattern: Pattern) -> PatternRef {
         self.resources.add_pattern(pattern)
     }
 
     /// __STUB__: Adds an XObject to the pages resources.
     /// __NOTE__: Watch out for scaling. Your XObject might be invisible or only 1pt x 1pt big
     #[inline]
-    pub fn add_xobject(&mut self, xobj: XObject)
-    -> XObjectRef
-    {
+    pub fn add_xobject(&mut self, xobj: XObject) -> XObjectRef {
         self.resources.add_xobject(xobj)
     }
 }
 
 impl PdfPageReference {
-
     /// Adds a page and returns the index of the currently added page
     #[inline]
-    pub fn add_layer<S>(&self, layer_name: S)
-    -> PdfLayerReference where S: Into<String>
+    pub fn add_layer<S>(&self, layer_name: S) -> PdfLayerReference
+    where
+        S: Into<String>,
     {
         let doc = self.document.upgrade().unwrap();
         let mut doc = doc.borrow_mut();
@@ -168,10 +170,8 @@ impl PdfPageReference {
 
     /// Validates that a layer is present and returns a reference to it
     #[inline]
-    #[cfg_attr(feature = "cargo-clippy", allow(no_effect))]
-    pub fn get_layer(&self, layer: PdfLayerIndex)
-    -> PdfLayerReference
-    {
+
+    pub fn get_layer(&self, layer: PdfLayerIndex) -> PdfLayerReference {
         let doc = self.document.upgrade().unwrap();
         let doc = doc.borrow();
 
@@ -180,7 +180,7 @@ impl PdfPageReference {
         PdfLayerReference {
             document: self.document.clone(),
             page: self.page,
-            layer: layer,
+            layer,
         }
     }
 }

--- a/src/pdf_resources.rs
+++ b/src/pdf_resources.rs
@@ -1,9 +1,8 @@
-use lopdf;
-use {
-    XObject, Pattern, ExtendedGraphicsState, ExtendedGraphicsStateList, 
-    PatternRef, OCGRef, XObjectList, XObjectRef, ExtendedGraphicsStateRef,
-    OCGList, PatternList
+use crate::{
+    ExtendedGraphicsState, ExtendedGraphicsStateList, ExtendedGraphicsStateRef, OCGList, OCGRef,
+    Pattern, PatternList, PatternRef, XObject, XObjectList, XObjectRef,
 };
+use lopdf;
 
 /// Struct for storing the PDF Resources, to be used on a PDF page
 #[derive(Default, Debug, Clone)]
@@ -19,79 +18,74 @@ pub struct PdfResources {
 }
 
 impl PdfResources {
-
     /// Creates a new PdfResources struct (resources for exactly one PDF page)
-    pub fn new()
-    -> Self
-    {
+    pub fn new() -> Self {
         Self::default()
     }
 
     /// Add a graphics state to the resources
     #[inline]
-    pub fn add_graphics_state(&mut self, added_state: ExtendedGraphicsState)
-    -> ExtendedGraphicsStateRef
-    {
+    pub fn add_graphics_state(
+        &mut self,
+        added_state: ExtendedGraphicsState,
+    ) -> ExtendedGraphicsStateRef {
         self.graphics_states.add_graphics_state(added_state)
     }
 
     /// Adds an XObject to the page
     #[inline]
-    pub fn add_xobject(&mut self, xobj: XObject)
-    -> XObjectRef
-    {
+    pub fn add_xobject(&mut self, xobj: XObject) -> XObjectRef {
         self.xobjects.add_xobject(xobj)
     }
 
     /// __STUB__: Adds a pattern to the resources, to be used like a color
     #[inline]
-    pub fn add_pattern(&mut self, pattern: Pattern)
-    -> PatternRef
-    {
+    pub fn add_pattern(&mut self, pattern: Pattern) -> PatternRef {
         self.patterns.add_pattern(pattern)
     }
 
     /// See `XObject::Into_with_document`.
     /// The resources also need access to the layers (the optional content groups), this should be a
     /// `Vec<lopdf::Object::Reference>` (to the actual OCG groups, which are added on the document level)
-    #[cfg_attr(feature = "cargo-clippy", allow(needless_return))]
-    pub fn into_with_document_and_layers(self, doc: &mut lopdf::Document, layers: Vec<lopdf::Object>)
-    -> (lopdf::Dictionary, Vec<OCGRef>)
-    {
-            let mut dict = lopdf::Dictionary::new();
 
-            let mut ocg_dict = self.layers;
-            let mut ocg_references = Vec::<OCGRef>::new();
+    pub fn into_with_document_and_layers(
+        self,
+        doc: &mut lopdf::Document,
+        layers: Vec<lopdf::Object>,
+    ) -> (lopdf::Dictionary, Vec<OCGRef>) {
+        let mut dict = lopdf::Dictionary::new();
 
-            let xobjects_dict: lopdf::Dictionary = self.xobjects.into_with_document(doc);
-            let patterns_dict: lopdf::Dictionary = self.patterns.into();
-            let graphics_state_dict: lopdf::Dictionary = self.graphics_states.into();
+        let mut ocg_dict = self.layers;
+        let mut ocg_references = Vec::<OCGRef>::new();
 
-            if !layers.is_empty() {
+        let xobjects_dict: lopdf::Dictionary = self.xobjects.into_with_document(doc);
+        let patterns_dict: lopdf::Dictionary = self.patterns.into();
+        let graphics_state_dict: lopdf::Dictionary = self.graphics_states.into();
 
-                for l in layers {
-                    ocg_references.push(ocg_dict.add_ocg(l));
-                }
-
-                let cur_ocg_dict_obj: lopdf::Dictionary = ocg_dict.into();
-
-                if cur_ocg_dict_obj.len() > 0 {
-                    dict.set("Properties", lopdf::Object::Dictionary(cur_ocg_dict_obj));
-                }
+        if !layers.is_empty() {
+            for l in layers {
+                ocg_references.push(ocg_dict.add_ocg(l));
             }
 
-            if xobjects_dict.len() > 0 {
-                dict.set("XObject", lopdf::Object::Dictionary(xobjects_dict));
-            }
+            let cur_ocg_dict_obj: lopdf::Dictionary = ocg_dict.into();
 
-            if patterns_dict.len() > 0 {
-                dict.set("Pattern", lopdf::Object::Dictionary(patterns_dict));
+            if !cur_ocg_dict_obj.is_empty() {
+                dict.set("Properties", lopdf::Object::Dictionary(cur_ocg_dict_obj));
             }
+        }
 
-            if graphics_state_dict.len() > 0 {
-                dict.set("ExtGState", lopdf::Object::Dictionary(graphics_state_dict));
-            }
+        if !xobjects_dict.is_empty() {
+            dict.set("XObject", lopdf::Object::Dictionary(xobjects_dict));
+        }
 
-            return (dict, ocg_references);
+        if !patterns_dict.is_empty() {
+            dict.set("Pattern", lopdf::Object::Dictionary(patterns_dict));
+        }
+
+        if !graphics_state_dict.is_empty() {
+            dict.set("ExtGState", lopdf::Object::Dictionary(graphics_state_dict));
+        }
+
+        (dict, ocg_references)
     }
 }

--- a/src/point.rs
+++ b/src/point.rs
@@ -1,4 +1,4 @@
-use {Mm, Pt};
+use crate::{Mm, Pt};
 
 #[derive(Debug, Copy, Clone)]
 pub struct Point {
@@ -9,13 +9,10 @@ pub struct Point {
 }
 
 impl Point {
-
     /// Create a new point.
     /// **WARNING: The reference point for a point is the bottom left corner, not the top left**
     #[inline]
-    pub fn new(x: Mm, y: Mm)
-    -> Self
-    {
+    pub fn new(x: Mm, y: Mm) -> Self {
         Self {
             x: x.into(),
             y: y.into(),
@@ -24,17 +21,22 @@ impl Point {
 }
 
 impl PartialEq for Point {
-
     // custom compare function because of floating point inaccuracy
     fn eq(&self, other: &Point) -> bool {
-
-        if self.x.0.is_normal() && other.x.0.is_normal() &&
-           self.y.0.is_normal() && other.y.0.is_normal() {
+        if self.x.0.is_normal()
+            && other.x.0.is_normal()
+            && self.y.0.is_normal()
+            && other.y.0.is_normal()
+        {
             // four floating point numbers have to match
             let x_eq = self.x == other.x;
-            if !x_eq { return false; }
+            if !x_eq {
+                return false;
+            }
             let y_eq = self.y == other.y;
-            if y_eq { return true; }
+            if y_eq {
+                return true;
+            }
         }
 
         false

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 //! Utility / conveniece functions for commonly use graphical shapes
 
-use scale::Pt;
-use Point;
+use crate::scale::Pt;
+use crate::Point;
 
 // PDF doesn't understand what a "circle" is, so we have to
 // approximate it.
@@ -18,30 +18,91 @@ pub fn calculate_points_for_circle<P: Into<Pt>>(
     let (radius, offset_x, offset_y) = (radius.into(), offset_x.into(), offset_y.into());
     let radius = radius.0;
 
-    let p10 = Point { x: Pt(0.0 * radius), y: Pt(1.0 * radius) };
-    let p11 = Point { x: Pt(C   * radius), y: Pt(1.0 * radius) };
-    let p12 = Point { x: Pt(1.0 * radius), y: Pt(C   * radius) };
-    let p13 = Point { x: Pt(1.0 * radius), y: Pt(0.0 * radius) };
+    let p10 = Point {
+        x: Pt(0.0 * radius),
+        y: Pt(1.0 * radius),
+    };
+    let p11 = Point {
+        x: Pt(C * radius),
+        y: Pt(1.0 * radius),
+    };
+    let p12 = Point {
+        x: Pt(1.0 * radius),
+        y: Pt(C * radius),
+    };
+    let p13 = Point {
+        x: Pt(1.0 * radius),
+        y: Pt(0.0 * radius),
+    };
 
-    let p20 = Point { x: Pt(1.0 * radius), y: Pt(0.0 * radius) };
-    let p21 = Point { x: Pt(1.0 * radius), y: Pt(-C  * radius) };
-    let p22 = Point { x: Pt(C   * radius), y: Pt(-1.0 * radius) };
-    let p23 = Point { x: Pt(0.0 * radius), y: Pt(-1.0 * radius) };
+    let p20 = Point {
+        x: Pt(1.0 * radius),
+        y: Pt(0.0 * radius),
+    };
+    let p21 = Point {
+        x: Pt(1.0 * radius),
+        y: Pt(-C * radius),
+    };
+    let p22 = Point {
+        x: Pt(C * radius),
+        y: Pt(-1.0 * radius),
+    };
+    let p23 = Point {
+        x: Pt(0.0 * radius),
+        y: Pt(-1.0 * radius),
+    };
 
-    let p30 = Point { x: Pt(0.0 * radius),  y: Pt(-1.0 * radius) };
-    let p31 = Point { x: Pt(-C  * radius),  y: Pt(-1.0 * radius) };
-    let p32 = Point { x: Pt(-1.0 * radius), y: Pt(-C   * radius) };
-    let p33 = Point { x: Pt(-1.0 * radius), y: Pt(0.0 * radius) };
+    let p30 = Point {
+        x: Pt(0.0 * radius),
+        y: Pt(-1.0 * radius),
+    };
+    let p31 = Point {
+        x: Pt(-C * radius),
+        y: Pt(-1.0 * radius),
+    };
+    let p32 = Point {
+        x: Pt(-1.0 * radius),
+        y: Pt(-C * radius),
+    };
+    let p33 = Point {
+        x: Pt(-1.0 * radius),
+        y: Pt(0.0 * radius),
+    };
 
-    let p40 = Point { x: Pt(-1.0 * radius), y: Pt(0.0 * radius) };
-    let p41 = Point { x: Pt(-1.0 * radius), y: Pt(C * radius) };
-    let p42 = Point { x: Pt(-C * radius),   y: Pt(1.0  * radius) };
-    let p43 = Point { x: Pt(0.0 * radius),  y: Pt(1.0 * radius) };
+    let p40 = Point {
+        x: Pt(-1.0 * radius),
+        y: Pt(0.0 * radius),
+    };
+    let p41 = Point {
+        x: Pt(-1.0 * radius),
+        y: Pt(C * radius),
+    };
+    let p42 = Point {
+        x: Pt(-C * radius),
+        y: Pt(1.0 * radius),
+    };
+    let p43 = Point {
+        x: Pt(0.0 * radius),
+        y: Pt(1.0 * radius),
+    };
 
-    let mut pts  = vec![(p10, true), (p11, true), (p12, true), (p13, false),
-                        (p20, true), (p21, true), (p22, true), (p23, false),
-                        (p30, true), (p31, true), (p32, true), (p33, false),
-                        (p40, true), (p41, true), (p42, true), (p43, false),
+    let mut pts = vec![
+        (p10, true),
+        (p11, true),
+        (p12, true),
+        (p13, false),
+        (p20, true),
+        (p21, true),
+        (p22, true),
+        (p23, false),
+        (p30, true),
+        (p31, true),
+        (p32, true),
+        (p33, false),
+        (p40, true),
+        (p41, true),
+        (p42, true),
+        (p43, false),
     ];
 
     for &mut (ref mut p, _) in pts.iter_mut() {
@@ -74,10 +135,18 @@ pub fn calculate_points_for_rect<P: Into<Pt>>(
 
     let top_left_pt = Point { x: left, y: top };
     let top_right_pt = Point { x: right, y: top };
-    let bottom_right_pt = Point { x: right, y: bottom };
+    let bottom_right_pt = Point {
+        x: right,
+        y: bottom,
+    };
     let bottom_left_pt = Point { x: left, y: bottom };
 
-    vec![(top_left_pt, false), (top_right_pt, false), (bottom_right_pt, false), (bottom_left_pt, false)]
+    vec![
+        (top_left_pt, false),
+        (top_right_pt, false),
+        (bottom_right_pt, false),
+        (bottom_left_pt, false),
+    ]
 }
 
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -90,14 +159,16 @@ static RAND_SEED: AtomicUsize = AtomicUsize::new(2100);
 /// Xorshift-based random number generator. Impure function
 pub(crate) fn rand() -> usize {
     let mut x = RAND_SEED.fetch_add(21, Ordering::SeqCst);
-    #[cfg(target_pointer_width = "64")] {
+    #[cfg(target_pointer_width = "64")]
+    {
         x ^= x << 21;
         x ^= x >> 35;
         x ^= x << 4;
         x
     }
 
-    #[cfg(target_pointer_width = "32")] {
+    #[cfg(target_pointer_width = "32")]
+    {
         x ^= x << 13;
         x ^= x >> 17;
         x ^= x << 5;
@@ -107,7 +178,6 @@ pub(crate) fn rand() -> usize {
 
 /// Returns a string with 32 random characters
 pub(crate) fn random_character_string_32() -> String {
-
     const MAX_CHARS: usize = 32;
     let mut final_string = String::with_capacity(MAX_CHARS);
     let mut char_pos = 0;
@@ -129,5 +199,5 @@ pub(crate) fn random_character_string_32() -> String {
 
 #[inline(always)]
 fn u8_to_char(input: u8) -> char {
-    ('A' as u8 + input) as char
+    (b'A' + input) as char
 }

--- a/src/xmp_metadata.rs
+++ b/src/xmp_metadata.rs
@@ -3,8 +3,8 @@
 use crate::OffsetDateTime;
 use lopdf;
 
-use PdfMetadata;
-use utils::random_character_string_32;
+use crate::utils::random_character_string_32;
+use crate::PdfMetadata;
 
 /// Initial struct for Xmp metatdata. This should be expanded later for XML handling, etc.
 /// Right now it just fills out the necessary fields
@@ -19,26 +19,21 @@ pub struct XmpMetadata {
 }
 
 impl XmpMetadata {
-
     /// Creates a new XmpMetadata object
-    pub fn new(rendition_class: Option<String>, document_version: u32)
-    -> Self
-    {
+    pub fn new(rendition_class: Option<String>, document_version: u32) -> Self {
         let document_id: String = random_character_string_32();
         Self {
-            document_id: document_id,
-            rendition_class: rendition_class,
-            document_version: document_version,
+            document_id,
+            rendition_class,
+            document_version,
         }
     }
 
     /// Consumes the XmpMetadata and turns it into a PDF Object.
     /// This is similar to the
-    pub(in crate) fn into_obj(self, m: &PdfMetadata)
-    -> lopdf::Object
-    {
-        use lopdf::{Stream as LoStream, Dictionary as LoDictionary};
+    pub(crate) fn into_obj(self, m: &PdfMetadata) -> lopdf::Object {
         use lopdf::Object::*;
+        use lopdf::{Dictionary as LoDictionary, Stream as LoStream};
         use std::iter::FromIterator;
 
         // Shared between XmpMetadata and DocumentInfo
@@ -59,40 +54,38 @@ impl XmpMetadata {
             None => "".to_string(),
         };
 
-        let xmp_metadata = format!(include_str!("../assets/catalog_xmp_metadata.txt"),
-                           create = create_date, 
-                           modify = modification_date, 
-                           mdate = metadata_date, 
-                           title = m.document_title, 
-                           id = document_id,
-                           instance = instance_id, 
-                           class = rendition_class, 
-                           version = document_version, 
-                           pdfx = pdf_x_version, 
-                           trapping = trapping, 
-                           creator = m.creator,
-                           subject = m.subject,
-                           keywords = m.keywords.join(","),
-                           identifier = m.identifier,
-                           producer = m.producer);
+        let xmp_metadata = format!(
+            include_str!("../assets/catalog_xmp_metadata.txt"),
+            create = create_date,
+            modify = modification_date,
+            mdate = metadata_date,
+            title = m.document_title,
+            id = document_id,
+            instance = instance_id,
+            class = rendition_class,
+            version = document_version,
+            pdfx = pdf_x_version,
+            trapping = trapping,
+            creator = m.creator,
+            subject = m.subject,
+            keywords = m.keywords.join(","),
+            identifier = m.identifier,
+            producer = m.producer
+        );
 
-
-
-
-        Stream(LoStream::new(LoDictionary::from_iter(vec![
-            ("Type", "Metadata".into()),
-            ("Subtype", "XML".into()), ]),
-            xmp_metadata.as_bytes().to_vec() ))
+        Stream(LoStream::new(
+            LoDictionary::from_iter(vec![("Type", "Metadata".into()), ("Subtype", "XML".into())]),
+            xmp_metadata.as_bytes().to_vec(),
+        ))
     }
 }
 
 // D:2018-09-19T10:05:05+00'00'
-fn to_pdf_xmp_date(date: &OffsetDateTime)
--> String
-{
+fn to_pdf_xmp_date(date: &OffsetDateTime) -> String {
     // Since the time is in UTC, we know that the time zone
     // difference to UTC is 0 min, 0 sec, hence the 00'00
-    format!("D:{:04}-{:02}-{:02}T{:02}:{:02}:{:02}+00'00'",
+    format!(
+        "D:{:04}-{:02}-{:02}T{:02}:{:02}:{:02}+00'00'",
         date.year(),
         date.month(),
         date.day(),


### PR DESCRIPTION
Working with the codebase was very cumbersome and doing any modification was generating a huge git diff.
Also, edition 2015 is really old and we have edition 2024 in the horizon.