### PR TITLE
Don't include unused fonts in the PDF document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13,6 +19,54 @@ name = "adler32"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
+name = "allsorts"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e926a9819dcf2211da0c19f5ca06a8f5c883e3bdb5ccc51afead3a7d995f023"
+dependencies = [
+ "bitflags",
+ "bitreader",
+ "brotli-decompressor",
+ "byteorder",
+ "encoding_rs",
+ "flate2",
+ "glyph-names",
+ "itertools",
+ "lazy_static",
+ "libc",
+ "log",
+ "num-traits",
+ "ouroboros",
+ "rustc-hash",
+ "tinyvec",
+ "ucd-trie",
+ "unicode-canonical-combining-class",
+ "unicode-general-category 0.6.0",
+ "unicode-joining-type",
+]
 
 [[package]]
 name = "arrayvec"
@@ -43,6 +97,25 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitreader"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d84ea71c85d1fe98fe67a9b9988b1695bc24c0b0d3bfb18d4c510f44b4b09941"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b6561fd3f895a11e8f72af2cb7d22e08366bebc2b6b57f7744c4bda27034744"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
 
 [[package]]
 name = "bumpalo"
@@ -234,6 +307,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,6 +351,12 @@ dependencies = [
  "color_quant",
  "weezl",
 ]
+
+[[package]]
+name = "glyph-names"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3531d702d6c1a3ba92a5fb55a404c7b8c476c8e7ca249951077afcbe4bc807f"
 
 [[package]]
 name = "hermit-abi"
@@ -311,6 +399,15 @@ dependencies = [
  "png 0.17.7",
  "scoped_threadpool",
  "tiff",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -595,6 +692,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -656,6 +777,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,7 +803,7 @@ dependencies = [
  "ttf-parser",
  "unicode-bidi-mirroring",
  "unicode-ccc",
- "unicode-general-category",
+ "unicode-general-category 0.4.0",
  "unicode-script",
 ]
 
@@ -917,10 +1044,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "ttf-parser"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ae2f58a822f08abdaf668897e96a5656fe72f5a9ce66422423e8849384872e6"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e79c4d996edb816c91e4308506774452e55e95c3c9de07b6729e17e15a5ef81"
 
 [[package]]
 name = "unicode-bidi"
@@ -935,6 +1083,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
 
 [[package]]
+name = "unicode-canonical-combining-class"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6925586af9268182c711e47c0853ed84131049efaca41776d0ca97f983865c32"
+
+[[package]]
 name = "unicode-ccc"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -945,6 +1099,12 @@ name = "unicode-general-category"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07547e3ee45e28326cc23faac56d44f58f16ab23e413db526debce3b0bfd2742"
+
+[[package]]
+name = "unicode-general-category"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["pdf", "gui", "graphics", "wkhtmltopdf"]
 categories = ["gui"]
 exclude = ["./assets/*", "./doc/*", "./examples/*"]
 autoexamples = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 # minimum dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ image = { version = "0.24.3", optional = true, default-features = false, feature
 svg2pdf = { version = "0.1.0", optional = true }
 pdf-writer = { version = "0.4.1", optional = true }
 usvg = { version = "0.19.0", optional = true }
+allsorts = { version = "0.14", optional = true, default-features = false, features = ["flate2_rust"]  }
 
 [features]
 default = []
@@ -54,6 +55,7 @@ dds = ["image/dds", "embedded_images"]
 webp = ["image/webp", "embedded_images"]
 # enables svg
 svg = ["svg2pdf", "usvg", "pdf-writer"]
+font_subsetting = ["dep:allsorts"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/document_info.rs
+++ b/src/document_info.rs
@@ -64,7 +64,6 @@ impl DocumentInfo {
         use lopdf::Dictionary as LoDictionary;
         use lopdf::Object::*;
         use lopdf::StringFormat::Literal;
-        use std::iter::FromIterator;
 
         let trapping = if m.trapping { "True" } else { "False" };
         let gts_pdfx_version = m.conformance.get_identifier_string();

--- a/src/document_info.rs
+++ b/src/document_info.rs
@@ -1,8 +1,8 @@
 //! Info dictionary of a PDF document
 
 use crate::OffsetDateTime;
-use lopdf;
 use crate::PdfMetadata;
+use lopdf;
 /// "Info" dictionary of a PDF document.
 /// Actual data is contained in `DocumentMetadata`, to keep it in sync with the `XmpMetadata`
 /// (if the timestamps / settings are not in sync, Preflight will complain)

--- a/src/extgstate.rs
+++ b/src/extgstate.rs
@@ -565,7 +565,6 @@ impl From<ExtendedGraphicsState> for lopdf::Object {
     /// comparison to the previous one are returned.
 
     fn from(val: ExtendedGraphicsState) -> Self {
-        use std::iter::FromIterator;
         let mut gs_operations = Vec::<(String, lopdf::Object)>::new();
 
         // for each field, look if it was contained in the "changed fields"
@@ -841,7 +840,6 @@ impl HalftoneType {
     }
 
     pub fn into_obj(self) -> Vec<lopdf::Object> {
-        use std::iter::FromIterator;
         vec![Dictionary(lopdf::Dictionary::from_iter(vec![
             ("Type", "Halftone".into()),
             ("HalftoneType", self.get_type().into()),

--- a/src/font.rs
+++ b/src/font.rs
@@ -9,6 +9,7 @@ use owned_ttf_parser::{AsFaceRef as _, Face, OwnedFace};
 use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::iter::FromIterator;
+use std::rc::Rc;
 
 /// The font
 #[derive(Debug, Clone, PartialEq)]
@@ -91,7 +92,7 @@ pub struct ExternalFont {
     /// Is the font written vertically? Default: false
     pub(crate) vertical_writing: bool,
     /// Is the font allowed to be subsetted (removing unused glyphs before embedding)? Default: true
-    pub(crate) allow_subsetting: RefCell<bool>,
+    pub(crate) allow_subsetting: Rc<RefCell<bool>>,
 }
 
 /// The text rendering mode determines how a text is drawn
@@ -157,7 +158,7 @@ impl ExternalFont {
             font_data,
             face_name,
             vertical_writing: false,
-            allow_subsetting: RefCell::new(true),
+            allow_subsetting: Rc::new(RefCell::new(true)),
         }
     }
 

--- a/src/icc_profile.rs
+++ b/src/icc_profile.rs
@@ -54,7 +54,6 @@ impl From<IccProfile> for lopdf::Stream {
     fn from(val: IccProfile) -> Self {
         use lopdf::Object::*;
         use lopdf::{Dictionary as LoDictionary, Stream as LoStream};
-        use std::iter::FromIterator;
 
         let (num_icc_fields, alternate) = match val.icc_type {
             IccProfileType::Cmyk => (4, "DeviceCMYK"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,9 @@
 //! current_layer.add_shape(line2);
 //! ```
 //!
-#![cfg_attr(feature = "embedded_images", doc = r##"
+#![cfg_attr(
+    feature = "embedded_images",
+    doc = r##"
 ### Adding images
 
 Note: Images only get compressed in release mode. You might get huge PDFs (6 or more MB) in
@@ -162,7 +164,8 @@ fn main() {
     let image2 = Image::from(image_file_2);
 }
 ```
-"##)]
+"##
+)]
 //! ### Adding fonts
 //!
 //! Note: Fonts are shared between pages. This means that they are added to the document first

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -357,6 +357,8 @@ pub mod svg;
 pub mod utils;
 pub mod xmp_metadata;
 pub mod xobject;
+#[cfg(feature = "font_subsetting")]
+pub(crate) mod subsetting;
 
 pub(crate) mod glob_defines {
 

--- a/src/pdf_document.rs
+++ b/src/pdf_document.rs
@@ -404,7 +404,6 @@ impl PdfDocumentReference {
         use lopdf::Object::*;
         use lopdf::StringFormat::Literal;
         use lopdf::{Dictionary as LoDictionary, Object as LoObject};
-        use std::iter::FromIterator;
         use std::mem;
 
         // todo: remove unwrap, handle error

--- a/src/pdf_document.rs
+++ b/src/pdf_document.rs
@@ -574,7 +574,7 @@ impl PdfDocumentReference {
         let mut font_dict_id = None;
 
         // add all fonts / other resources shared in the whole document
-        let fonts_dict: lopdf::Dictionary = doc.fonts.into_with_document(&mut doc.inner_doc);
+        let fonts_dict: lopdf::Dictionary = doc.fonts.into_with_document(&mut doc.inner_doc, &mut doc.pages);
 
         if !fonts_dict.is_empty() {
             font_dict_id = Some(doc.inner_doc.add_object(Dictionary(fonts_dict)));

--- a/src/pdf_document.rs
+++ b/src/pdf_document.rs
@@ -310,6 +310,7 @@ impl PdfDocumentReference {
     }
 
     /// Add a font from a font stream and set the whether or not to allow subsetting the font
+    #[cfg(feature = "font_subsetting")]
     pub fn add_external_font_with_subsetting<R>(
         &self,
         font_stream: R,
@@ -351,6 +352,7 @@ impl PdfDocumentReference {
 
     /// Add a font from a custom font backend and set the whether or not to allow subsetting the
     /// font
+    #[cfg(feature = "font_subsetting")]
     pub fn add_external_font_data_with_subsetting<F>(
         &self,
         bytes: Vec<u8>,

--- a/src/pdf_metadata.rs
+++ b/src/pdf_metadata.rs
@@ -1,8 +1,8 @@
 //! Wapper type for shared metadata between XMP Metadata and the `DocumentInfo` dictionary
 
 use crate::OffsetDateTime;
-use lopdf;
 use crate::{DocumentInfo, IccProfile, IccProfileType, PdfConformance, XmpMetadata};
+use lopdf;
 
 use crate::glob_defines::ICC_PROFILE_ECI_V2;
 

--- a/src/pdf_page.rs
+++ b/src/pdf_page.rs
@@ -87,9 +87,7 @@ impl PdfPage {
 
         for (idx, mut layer) in self.layers.into_iter().enumerate() {
             // push OCG and q to the beginning of the layer
-            layer
-                .operations
-                .insert(0, Operation::new("q", vec![]));
+            layer.operations.insert(0, Operation::new("q", vec![]));
             layer.operations.insert(
                 0,
                 Operation::new(

--- a/src/subsetting.rs
+++ b/src/subsetting.rs
@@ -1,0 +1,54 @@
+use allsorts::{
+    binary::read::ReadScope,
+    font::read_cmap_subtable,
+    font_data::FontData,
+    tables::{cmap::Cmap, FontTableProvider},
+    tag,
+};
+use std::collections::{HashMap, HashSet};
+
+pub(crate) fn subset(
+    font_bytes: &[u8],
+    used_glyphs: &mut HashSet<u16>,
+) -> (Vec<u8>, HashMap<u16, u16>) {
+    let font_file = ReadScope::new(font_bytes).read::<FontData<'_>>().unwrap();
+    let provider = font_file.table_provider(0).unwrap();
+    let cmap_data = provider.read_table_data(tag::CMAP).unwrap();
+    let cmap = ReadScope::new(&cmap_data).read::<Cmap<'_>>().unwrap();
+    let (_, cmap_subtable) = read_cmap_subtable(&cmap).unwrap().unwrap();
+
+    // Prevent `allsorts` from using MacRoman encoding by using a non supported character
+    let gid_eur = cmap_subtable.map_glyph('€' as u32).unwrap().unwrap();
+    used_glyphs.insert(0);
+    used_glyphs.insert(gid_eur);
+
+    let mut glyph_ids: Vec<u16> = used_glyphs.iter().copied().collect();
+
+    glyph_ids.sort_unstable();
+
+    let mut gid_char_map = Vec::new();
+    cmap_subtable
+        .mappings_fn(|ch, gid| {
+            if used_glyphs.contains(&gid) {
+                gid_char_map.push((gid, ch));
+            }
+        })
+        .unwrap();
+
+    let new_font = allsorts::subset::subset(&provider, &glyph_ids).unwrap();
+
+    let font_file = ReadScope::new(&new_font).read::<FontData<'_>>().unwrap();
+    let provider = font_file.table_provider(0).unwrap();
+    let cmap_data = provider.read_table_data(tag::CMAP).unwrap();
+    let cmap = ReadScope::new(&cmap_data).read::<Cmap<'_>>().unwrap();
+    let (_, cmap_subtable) = read_cmap_subtable(&cmap).unwrap().unwrap();
+
+    let mut gid_mapping = HashMap::new();
+    for (old_gid, ch) in gid_char_map {
+        let new_gid = cmap_subtable.map_glyph(ch).unwrap().unwrap();
+        gid_mapping.insert(old_gid, new_gid);
+    }
+
+    drop(provider);
+    (new_font, gid_mapping)
+}

--- a/src/subsetting.rs
+++ b/src/subsetting.rs
@@ -5,7 +5,10 @@ use allsorts::{
     tables::{cmap::Cmap, FontTableProvider},
     tag,
 };
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+};
 
 pub(crate) struct FontSubset {
     pub(crate) new_font_bytes: Vec<u8>,
@@ -13,15 +16,21 @@ pub(crate) struct FontSubset {
     pub(crate) gid_mapping: HashMap<u16, u16>,
 }
 
-pub(crate) fn subset(font_bytes: &[u8], used_glyphs: &mut HashSet<u16>) -> FontSubset {
-    let font_file = ReadScope::new(font_bytes).read::<FontData<'_>>().unwrap();
-    let provider = font_file.table_provider(0).unwrap();
-    let cmap_data = provider.read_table_data(tag::CMAP).unwrap();
-    let cmap = ReadScope::new(&cmap_data).read::<Cmap<'_>>().unwrap();
-    let (_, cmap_subtable) = read_cmap_subtable(&cmap).unwrap().unwrap();
+pub(crate) fn subset(
+    font_bytes: &[u8],
+    used_glyphs: &mut HashSet<u16>,
+) -> Result<FontSubset, Box<dyn Error>> {
+    let font_file = ReadScope::new(font_bytes).read::<FontData<'_>>()?;
+    let provider = font_file.table_provider(0)?;
+    let cmap_data = provider.read_table_data(tag::CMAP)?;
+    let cmap = ReadScope::new(&cmap_data).read::<Cmap<'_>>()?;
+    let (_, cmap_subtable) =
+        read_cmap_subtable(&cmap)?.ok_or(allsorts::error::ParseError::MissingValue)?;
 
     // Prevent `allsorts` from using MacRoman encoding by using a non supported character
-    let gid_eur = cmap_subtable.map_glyph('€' as u32).unwrap().unwrap();
+    let gid_eur = cmap_subtable
+        .map_glyph('€' as u32)?
+        .ok_or(allsorts::error::ParseError::MissingValue)?;
     used_glyphs.insert(0);
     used_glyphs.insert(gid_eur);
 
@@ -29,15 +38,15 @@ pub(crate) fn subset(font_bytes: &[u8], used_glyphs: &mut HashSet<u16>) -> FontS
 
     glyph_ids.sort_unstable();
 
-    let new_font_bytes = allsorts::subset::subset(&provider, &glyph_ids).unwrap();
+    let new_font_bytes = allsorts::subset::subset(&provider, &glyph_ids)?;
 
     let mut gid_mapping = HashMap::new();
     for (idx, old_gid) in glyph_ids.into_iter().enumerate() {
         gid_mapping.insert(old_gid, idx as u16);
     }
 
-    FontSubset {
+    Ok(FontSubset {
         new_font_bytes,
         gid_mapping,
-    }
+    })
 }

--- a/src/xmp_metadata.rs
+++ b/src/xmp_metadata.rs
@@ -34,7 +34,6 @@ impl XmpMetadata {
     pub(crate) fn into_obj(self, m: &PdfMetadata) -> lopdf::Object {
         use lopdf::Object::*;
         use lopdf::{Dictionary as LoDictionary, Stream as LoStream};
-        use std::iter::FromIterator;
 
         // Shared between XmpMetadata and DocumentInfo
         let trapping = if m.trapping { "True" } else { "False" };

--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -234,7 +234,6 @@ impl ImageXObject {
 impl From<ImageXObject> for lopdf::Stream {
     fn from(img: ImageXObject) -> lopdf::Stream {
         use lopdf::Object::*;
-        use std::iter::FromIterator;
 
         let cs: &'static str = img.color_space.into();
         let bbox: lopdf::Object = img.clipping_bbox.unwrap_or(CurTransMat::Identity).into();
@@ -397,7 +396,6 @@ pub struct FormXObject {
 impl From<FormXObject> for lopdf::Stream {
     fn from(val: FormXObject) -> Self {
         use lopdf::Object::*;
-        use std::iter::FromIterator;
 
         let dict = lopdf::Dictionary::from_iter(vec![
             ("Type", Name("XObject".as_bytes().to_vec())),


### PR DESCRIPTION
So I have seen some talk about using `allsorts` to do actual subsetting which would significantly reduce the PDF size. This is not actually removing glyphs but at least it is omitting completely unused fonts from the PDF output. 

I am using the `PdfLayerReference::set_font` function to mark fonts as used and then skip unmarked fonts in `FontList::into_with_document`. This is a rather simple *hack*, but it allows for adding all the fonts you want without wasting space on fonts / font variants that are not used at all. The main usecase for me is with the `genpdf` create where it is required to add all 4 variants of a font (regular, italic, bold, italic-bold) even if not all of them are used.

Let me know if there is something I missed here which could cause problems