### PR TITLE
Wasm build fails due to multiple moves (js_sys::Date does not copy)

### DIFF
--- a/src/pdf_metadata.rs
+++ b/src/pdf_metadata.rs
@@ -58,8 +58,8 @@ impl PdfMetadata {
         let current_time = OffsetDateTime::now_utc();
 
         Self {
-            creation_date: current_time,
-            modification_date: current_time,
+            creation_date: current_time.clone(),
+            modification_date: current_time.clone(),
             metadata_date: current_time,
             document_title: title.into(),
             author: String::new(),


### PR DESCRIPTION
cargo build --target wasm32-unknown-unknown

error[E0382]: use of moved value: `current_time`
  --> src\pdf_metadata.rs:62:32
   |
58 |         let current_time = OffsetDateTime::now_utc();
   |             ------------ move occurs because `current_time` has type `js_sys_date::OffsetDateTime`, which does not implement the `Copy` trait
...
61 |             creation_date: current_time,
   |                            ------------ value moved here
62 |             modification_date: current_time,
   |                                ^^^^^^^^^^^^ value used here after move

error[E0382]: use of moved value: `current_time`
  --> src\pdf_metadata.rs:63:28
   |
58 |         let current_time = OffsetDateTime::now_utc();
   |             ------------ move occurs because `current_time` has type `js_sys_date::OffsetDateTime`, which does not implement the `Copy` trait
...
62 |             modification_date: current_time,
   |                                ------------ value moved here
63 |             metadata_date: current_time,
   |                            ^^^^^^^^^^^^ value used here after move