### PR TITLE
Adds escape hatch for pages to add annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
+name = "ouroboros"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1358bd1558bd2a083fed428ffeda486fbfb323e698cdda7794259d592ca72db"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f7d21ccd03305a674437ee1248f3ab5d4b1db095cf1caf49f1713ddf61956b7"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +703,7 @@ checksum = "07e2192780e9f8e282049ff9bffcaa28171e1cb0844f49ed5374e518ae6024ec"
 name = "printpdf"
 version = "0.5.3"
 dependencies = [
+ "allsorts",
  "image 0.24.5",
  "js-sys",
  "log",
@@ -1111,6 +1135,12 @@ name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-joining-type"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f8cb47ccb8bc750808755af3071da4a10dcd147b68fc874b7ae4b12543f6f5"
 
 [[package]]
 name = "unicode-script"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,3 +98,7 @@ required-features = []
 [[example]]
 name = "svg"
 required-features = ["svg"]
+
+[[example]]
+name = "annotations"
+required-features = []

--- a/examples/annotations.rs
+++ b/examples/annotations.rs
@@ -1,4 +1,4 @@
-//! Embeds the SVG image on the page
+//! Uses the extend_with feature to add a link to the page.
 extern crate printpdf;
 
 use printpdf::*;

--- a/examples/annotations.rs
+++ b/examples/annotations.rs
@@ -27,7 +27,7 @@ fn main() {
         ("Subtype", Object::Name(b"Link".to_vec())),
         ("Rect", vec![20.into(), 580.into(), 300.into(), 560.into()].into()),
         ("C", vec![].into()),
-        ("Contents", Object::String("Hello ñandu".into(), Literal)),
+        ("Contents", Object::String("Hello World".into(), Literal)),
         ("A", action.into()),
     ]);
 

--- a/examples/annotations.rs
+++ b/examples/annotations.rs
@@ -1,0 +1,46 @@
+//! Embeds the SVG image on the page
+extern crate printpdf;
+
+use printpdf::*;
+use std::fs::File;
+use std::io::BufWriter;
+use lopdf::{
+  StringFormat::Literal,
+  Dictionary,
+  Object
+};
+
+fn main() {
+    let (doc, page1, layer1) =
+        PdfDocument::new("printpdf graphics test", Mm(210.0), Mm(297.0), "Layer 1");
+    let page = doc.get_page(page1);
+    let current_layer = page.get_layer(layer1);
+
+    let action = Dictionary::from_iter(vec![
+      ("Type", "Action".into()),
+      ("S", Object::Name(b"URI".to_vec())),
+      ("URI", Object::String(b"https://github.com/fschutt/printpdf".to_vec(), Literal)),
+    ]);
+
+    let annotation = Dictionary::from_iter(vec![
+        ("Type", "Annot".into()),
+        ("Subtype", Object::Name(b"Link".to_vec())),
+        ("Rect", vec![20.into(), 580.into(), 300.into(), 560.into()].into()),
+        ("C", vec![].into()),
+        ("Contents", Object::String("Hello ñandu".into(), Literal)),
+        ("A", action.into()),
+    ]);
+
+    let annotations = Dictionary::from_iter(vec![
+        ("Annots", Object::Array(vec![annotation.into()]))
+    ]);
+
+    page.extend_with(annotations);
+
+    let text = "There's an invisible annotation with a link covering this text.";
+    let font = doc.add_builtin_font(BuiltinFont::Helvetica).unwrap();
+    current_layer.use_text(text, 10.0, Mm(10.0), Mm(200.0), &font);
+
+    doc.save(&mut BufWriter::new(File::create("test_annotations.pdf").unwrap()))
+        .unwrap();
+}

--- a/src/pdf_document.rs
+++ b/src/pdf_document.rs
@@ -648,6 +648,10 @@ impl PdfDocumentReference {
                 ("Parent", Reference(pages_id)),
             ]);
 
+            if let Some(extended) = &page.extend_with {
+              p.extend(&extended)
+            }
+
             // this will collect the resources needed for rendering this page
             let layers_temp = ocg_list.iter().find(|e| e.0 == idx).unwrap();
             let (mut resources_page, layer_streams) =

--- a/src/pdf_document.rs
+++ b/src/pdf_document.rs
@@ -648,8 +648,10 @@ impl PdfDocumentReference {
                 ("Parent", Reference(pages_id)),
             ]);
 
-            if let Some(extended) = &page.extend_with {
-              p.extend(&extended)
+            if let Some(extension) = &page.extend_with {
+              for (key, value) in extension.iter() {
+                p.set(key.to_vec(), value.clone())
+              }
             }
 
             // this will collect the resources needed for rendering this page

--- a/src/pdf_page.rs
+++ b/src/pdf_page.rs
@@ -23,6 +23,10 @@ pub struct PdfPage {
     pub layers: Vec<PdfLayer>,
     /// Resources used in this page
     pub(crate) resources: PdfResources,
+    /// Extend the page with custom ad-hoc attributes, as an escape hatch to the low level lopdf library.
+    /// Can be used to add annotations to a page.
+    /// If your dictionary is wrong it will produce a broken PDF without warning or useful messages.
+    pub(crate) extend_with: Option<lopdf::Dictionary>,
 }
 
 /// A "reference" to the current page, allows for inner mutability
@@ -48,6 +52,7 @@ impl PdfPage {
             height: height.into(),
             layers: Vec::new(),
             resources: PdfResources::new(),
+            extend_with: None
         };
 
         let initial_layer = PdfLayer::new(layer_name);
@@ -180,5 +185,13 @@ impl PdfPageReference {
             page: self.page,
             layer,
         }
+    }
+
+    #[inline]
+    pub fn extend_with(&self, dict: lopdf::Dictionary) {
+        let doc = self.document.upgrade().unwrap();
+        let mut doc = doc.borrow_mut();
+        let page = &mut doc.pages[self.page.0];
+        page.extend_with = Some(dict);
     }
 }


### PR DESCRIPTION
Hi,

I need to apologize in advance for making this PR overlooking all the contributing guidelines.

Take it as the beginning of a discussion rather than something I expect you to merge right away.

This is the only PDF generation library I found that supports custom fonts, unicode and SVG out of the box, but I was only missing annotations because I need to put links on my PDFs.

2 hours ago I had no idea how PDF works internally, but looking at your code and the output from other PDF libraries I made a scape hatch to lopdf in the Page struct, so that it can be extended with arbitrary PDF dictionaries.

I added a specific example adding a link to some text because from all the different types of annotations, I think links may be the most useful.

Maybe it's something that can be kept around until there's a proper implementation for all the missing features, at which point people should stop using this error-prone variant and instead use specific functions that do the type checking.

Thanks for the great work.