### PR TITLE
derive Clone for Svgs

### DIFF
--- a/src/svg.rs
+++ b/src/svg.rs
@@ -6,7 +6,11 @@ use lopdf::{Object, Stream};
 use std::{error, fmt};
 
 /// SVG - wrapper around an `XObject` to allow for more
-/// control within the library
+/// control within the library. 
+/// When creating placing multiple copies of the same SVGs
+/// on the same layer, it is better to use the
+/// `into_xobject` method to get a reference, rather than a
+/// clone
 #[derive(Debug, Clone)]
 pub struct Svg {
     /// The PDF document, converted from SVG using svg2pdf

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -7,7 +7,7 @@ use std::{error, fmt};
 
 /// SVG - wrapper around an `XObject` to allow for more
 /// control within the library
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Svg {
     /// The PDF document, converted from SVG using svg2pdf
     svg_xobject: Stream,

--- a/src/svg.rs
+++ b/src/svg.rs
@@ -6,11 +6,11 @@ use lopdf::{Object, Stream};
 use std::{error, fmt};
 
 /// SVG - wrapper around an `XObject` to allow for more
-/// control within the library. 
-/// When creating placing multiple copies of the same SVGs
-/// on the same layer, it is better to use the
-/// `into_xobject` method to get a reference, rather than a
-/// clone
+/// control within the library.
+/// 
+/// When placing multiple copies of the same SVG on the 
+/// same layer, it is better to use the `into_xobject` 
+/// method to get a reference, rather than a clone
 #[derive(Debug, Clone)]
 pub struct Svg {
     /// The PDF document, converted from SVG using svg2pdf


### PR DESCRIPTION
This is useful when you need multiple SVGs on layers or on different documents, and do not want to go through the expensive process of manually parsing an SVG again.