### PR TITLE
add hyperlink support using link annotations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,8 @@ webp = ["image/webp", "embedded_images"]
 # enables svg
 svg = ["svg2pdf", "usvg", "pdf-writer"]
 font_subsetting = ["dep:allsorts"]
+# enables annotations
+annotations = ["pdf-writer"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -98,3 +100,7 @@ required-features = []
 [[example]]
 name = "svg"
 required-features = ["svg"]
+
+[[example]]
+name = "hyperlink"
+required-features = ["annotations"]

--- a/examples/hyperlink.rs
+++ b/examples/hyperlink.rs
@@ -1,0 +1,28 @@
+extern crate printpdf;
+
+use printpdf::*;
+use std::fs::File;
+use std::io::BufWriter;
+
+fn main() {
+    let (doc, page1, layer1) =
+        PdfDocument::new("printpdf graphics test", Mm(595.276), Mm(841.89), "Layer 1");
+    let current_layer = doc.get_page(page1).get_layer(layer1);
+
+    let text = "Lorem ipsum";
+    let font = doc.add_builtin_font(BuiltinFont::TimesBoldItalic).unwrap();
+    current_layer.use_text(text, 48.0, Mm(10.0), Mm(200.0), &font);
+
+    current_layer.add_link_annotation(LinkAnnotation::new(
+        printpdf::Rect::new(Mm(10.0), Mm(200.0), Mm(100.0), Mm(212.0)),
+        Some(printpdf::BorderArray::default()),
+        Some(printpdf::ColorArray::default()),
+        printpdf::Actions::uri("https://www.google.com/".to_string()),
+        Some(printpdf::HighlightingMode::Invert),
+    ));
+
+    doc.save(&mut BufWriter::new(
+        File::create("test_hyperlink.pdf").unwrap(),
+    ))
+    .unwrap();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,7 @@ pub mod icc_profile;
 pub mod image;
 pub mod indices;
 pub mod line;
+pub mod link_annotation;
 pub mod ocg;
 pub mod pattern;
 pub mod pdf_conformance;
@@ -352,6 +353,7 @@ pub mod pdf_metadata;
 pub mod pdf_page;
 pub mod pdf_resources;
 pub mod point;
+pub mod rectangle;
 pub mod scale;
 #[cfg(feature = "svg")]
 pub mod svg;
@@ -483,6 +485,8 @@ pub use crate::indices::*;
 #[doc(inline)]
 pub use crate::line::*;
 #[doc(inline)]
+pub use crate::link_annotation::*;
+#[doc(inline)]
 pub use crate::ocg::*;
 #[doc(inline)]
 pub use crate::pattern::*;
@@ -500,6 +504,8 @@ pub use crate::pdf_page::*;
 pub use crate::pdf_resources::*;
 #[doc(inline)]
 pub use crate::point::*;
+#[doc(inline)]
+pub use crate::rectangle::*;
 #[doc(inline)]
 pub use crate::scale::*;
 #[cfg(feature = "svg")]

--- a/src/link_annotation.rs
+++ b/src/link_annotation.rs
@@ -232,7 +232,10 @@ impl LinkAnnotationList {
 
 impl From<LinkAnnotationList> for lopdf::Dictionary {
     fn from(_val: LinkAnnotationList) -> Self {
-        // todo
+        if _val.link_annotations.is_empty() {
+            return lopdf::Dictionary::new();
+        }
+        
         let mut dict = lopdf::Dictionary::new();
         dict.set("Type", lopdf::Object::Name("Annot".as_bytes().to_vec()));
         dict.set("Subtype", lopdf::Object::Name("Link".as_bytes().to_vec()));

--- a/src/link_annotation.rs
+++ b/src/link_annotation.rs
@@ -1,0 +1,250 @@
+use lopdf::{self, Object};
+use std::collections::HashMap;
+use crate::Rect;
+
+#[derive(Debug, Clone)]
+pub struct LinkAnnotation {
+    pub rect: Rect,
+    pub border: BorderArray,
+    pub c: ColorArray,
+    pub a: Actions,
+    pub h: HighlightingMode,
+}
+
+impl LinkAnnotation {
+    /// Creates a new LinkAnnotation
+    pub fn new(
+        rect: Rect,
+        border: Option<BorderArray>,
+        c: Option<ColorArray>,
+        a: Actions,
+        h: Option<HighlightingMode>,
+    ) -> Self {
+        Self {
+            rect,
+            border: border.unwrap_or_default(),
+            c: c.unwrap_or_default(),
+            a,
+            h: h.unwrap_or_default(),
+        }
+    }
+}
+
+impl Into<Object> for LinkAnnotation {
+    fn into(self) -> Object {
+        let mut dict = lopdf::Dictionary::new();
+        dict.set("Type", lopdf::Object::Name("Annot".as_bytes().to_vec()));
+        dict.set("Subtype", lopdf::Object::Name("Link".as_bytes().to_vec()));
+        dict.set(
+            "Rect",
+            lopdf::Object::Array(vec![
+                self.rect.ll.x.into(),
+                self.rect.ll.y.into(),
+                self.rect.ur.x.into(),
+                self.rect.ur.y.into(),
+            ]),
+        );
+
+        dict.set::<&str, Object>("A", self.a.into());
+        dict.set::<&str, Object>("Border", self.border.into());
+        dict.set::<&str, Object>("C", self.c.into());
+        dict.set::<&str, Object>("H", self.h.into());
+
+        Object::Dictionary(dict)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum BorderArray {
+    Solid([f32; 3]),
+    Dashed([f32; 3], DashPhase),
+}
+
+impl Default for BorderArray {
+    fn default() -> Self {
+        BorderArray::Solid([0.0, 0.0, 1.0])
+    }
+}
+
+impl Into<Object> for BorderArray {
+    fn into(self) -> Object {
+        match self {
+            BorderArray::Solid(arr) => Object::Array(vec![
+                Object::Real(arr[0].into()),
+                Object::Real(arr[1].into()),
+                Object::Real(arr[2].into()),
+            ]),
+            BorderArray::Dashed(arr, phase) => Object::Array(vec![
+                Object::Real(arr[0].into()),
+                Object::Real(arr[1].into()),
+                Object::Real(arr[2].into()),
+                Object::Real(phase.phase.into()),
+            ]),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DashPhase {
+    pub dash_array: Vec<f32>,
+    pub phase: f32,
+}
+
+impl Into<Object> for DashPhase {
+    fn into(self) -> Object {
+        Object::Array(vec![
+            Object::Array(self.dash_array.into_iter().map(|x| Object::Real(x.into())).collect()),
+            Object::Real(self.phase.into()),
+        ])
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum ColorArray {
+    Transparent,
+    Gray([f32; 1]),
+    RGB([f32; 3]),
+    CMYK([f32; 4]),
+}
+
+impl Default for ColorArray {
+    fn default() -> Self {
+        ColorArray::RGB([0.0, 1.0, 1.0])
+    }
+}
+
+impl Into<Object> for ColorArray {
+    fn into(self) -> Object {
+        match self {
+            ColorArray::Transparent => Object::Array(vec![]),
+            ColorArray::Gray(arr) => Object::Array(vec![
+                Object::Real(arr[0].into()),
+            ]),
+            ColorArray::RGB(arr) => Object::Array(vec![
+                Object::Real(arr[0].into()),
+                Object::Real(arr[1].into()),
+                Object::Real(arr[2].into()),
+            ]),
+            ColorArray::CMYK(arr) => Object::Array(vec![
+                Object::Real(arr[0].into()),
+                Object::Real(arr[1].into()),
+                Object::Real(arr[2].into()),
+                Object::Real(arr[3].into()),
+            ]),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Actions {
+    pub s: String,
+    pub uri: String,
+}
+
+impl Actions {
+    pub fn uri(uri: String) -> Self {
+        Self {
+            s: "URI".to_string(),
+            uri,
+        }
+    }
+}
+
+impl Into<Object> for Actions {
+    fn into(self) -> Object {
+        let mut dict = lopdf::Dictionary::new();
+        dict.set("S", Object::Name(self.s.into_bytes().to_vec()));
+        dict.set("URI", Object::String(self.uri.into_bytes().to_vec(), lopdf::StringFormat::Literal));
+        Object::Dictionary(dict)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum HighlightingMode {
+    None,
+    Invert,
+    Outline,
+    Push,
+}
+
+impl Default for HighlightingMode {
+    fn default() -> Self {
+        HighlightingMode::Invert
+    }
+}
+
+impl Into<Object> for HighlightingMode {
+    fn into(self) -> Object {
+        match self {
+            HighlightingMode::None => Object::Name("N".as_bytes().to_vec()),
+            HighlightingMode::Invert => Object::Name("I".as_bytes().to_vec()),
+            HighlightingMode::Outline => Object::Name("O".as_bytes().to_vec()),
+            HighlightingMode::Push => Object::Name("P".as_bytes().to_vec()),
+        }
+    }
+}
+
+/// Named reference to a LinkAnnotation
+#[derive(Debug)]
+pub struct LinkAnnotationRef {
+    pub(crate) name: String,
+}
+
+impl LinkAnnotationRef {
+    pub fn new(index: usize) -> Self {
+        Self {
+            name: format!("PT{index}"),
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone)]
+pub struct LinkAnnotationList {
+    link_annotations: HashMap<String, LinkAnnotation>,
+}
+
+impl IntoIterator for LinkAnnotationList {
+    type Item = (String, LinkAnnotation);
+    type IntoIter = std::collections::hash_map::IntoIter<String, LinkAnnotation>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.link_annotations.into_iter()
+    }
+}
+
+impl LinkAnnotationList {
+    /// Creates a new LinkAnnotation list
+    pub fn new() -> Self {
+        Self {
+            link_annotations: HashMap::new(),
+        }
+    }
+
+    /// Adds a new LinkAnnotation to the LinkAnnotation list
+    pub fn add_link_annotation(&mut self, link_annotation: LinkAnnotation) -> LinkAnnotationRef {
+        let len = self.link_annotations.len();
+        let link_annotation_ref = LinkAnnotationRef::new(len);
+        self.link_annotations
+            .insert(link_annotation_ref.name.clone(), link_annotation);
+        link_annotation_ref
+    }
+}
+
+impl From<LinkAnnotationList> for lopdf::Dictionary {
+    fn from(_val: LinkAnnotationList) -> Self {
+        // todo
+        let mut dict = lopdf::Dictionary::new();
+        dict.set("Type", lopdf::Object::Name("Annot".as_bytes().to_vec()));
+        dict.set("Subtype", lopdf::Object::Name("Link".as_bytes().to_vec()));
+        dict.set(
+            "Rect",
+            lopdf::Object::Array(vec![
+                _val.link_annotations["PT0"].rect.ll.x.into(),
+                _val.link_annotations["PT0"].rect.ll.y.into(),
+                _val.link_annotations["PT0"].rect.ur.x.into(),
+                _val.link_annotations["PT0"].rect.ur.y.into(),
+            ]),
+        );
+        dict
+    }
+}

--- a/src/pdf_document.rs
+++ b/src/pdf_document.rs
@@ -630,6 +630,14 @@ impl PdfDocumentReference {
         let mut page_id_to_obj: HashMap<usize, (u32, u16)> = HashMap::new();
 
         for (idx, page) in doc.pages.into_iter().enumerate() {
+            let annotation_ids = page
+                .resources
+                .link_annotations
+                .clone()
+                .into_iter()
+                .map(|(_, annotation)| doc.inner_doc.add_object(annotation))
+                .collect::<Vec<_>>();
+
             let mut p = LoDictionary::from_iter(vec![
                 ("Type", "Page".into()),
                 ("Rotate", Integer(0)),
@@ -644,6 +652,14 @@ impl PdfDocumentReference {
                 (
                     "CropBox",
                     vec![0.into(), 0.into(), page.width.into(), page.height.into()].into(),
+                ),
+                (
+                    "Annots",
+                    annotation_ids
+                        .iter()
+                        .map(|id| Reference(*id))
+                        .collect::<Vec<LoObject>>()
+                        .into(),
                 ),
                 ("Parent", Reference(pages_id)),
             ]);

--- a/src/pdf_layer.rs
+++ b/src/pdf_layer.rs
@@ -2,7 +2,12 @@
 
 use crate::glob_defines::OP_PATH_STATE_SET_LINE_WIDTH;
 use crate::indices::{PdfLayerIndex, PdfPageIndex};
-use crate::{BlendMode, Color, CurTransMat, ExtendedGraphicsStateBuilder, Font, ImageXObject, IndirectFontRef, Line, LineCapStyle, LineDashPattern, LineJoinStyle, Mm, PdfColor, PdfDocument, Pt, TextMatrix, TextRenderingMode, XObject, XObjectRef};
+use crate::{
+    BlendMode, Color, CurTransMat, ExtendedGraphicsStateBuilder, Font, ImageXObject,
+    IndirectFontRef, Line, LineCapStyle, LineDashPattern, LineJoinStyle, LinkAnnotation,
+    LinkAnnotationRef, Mm, PdfColor, PdfDocument, Pt, TextMatrix, TextRenderingMode, XObject,
+    XObjectRef,
+};
 use lopdf::content::Operation;
 use std::cell::RefCell;
 use std::rc::Weak;
@@ -85,6 +90,18 @@ impl PdfLayerReference {
         let page_mut = &mut doc.pages[self.page.0];
 
         page_mut.add_xobject(xobject.into())
+    }
+
+    pub fn add_link_annotation<T>(&self, annotation: T) -> LinkAnnotationRef
+    where
+        T: Into<LinkAnnotation>,
+    {
+        let doc = self.document.upgrade().unwrap();
+        let mut doc = doc.borrow_mut();
+        let page_mut = &mut doc.pages[self.page.0];
+
+        let annot_ref = page_mut.add_link_annotation(annotation.into());
+        annot_ref
     }
 
     /// Begins a new text section

--- a/src/pdf_page.rs
+++ b/src/pdf_page.rs
@@ -7,7 +7,7 @@ use std::rc::Weak;
 use crate::indices::{PdfLayerIndex, PdfPageIndex};
 use crate::{
     ExtendedGraphicsState, ExtendedGraphicsStateRef, Mm, Pattern, PatternRef, PdfDocument,
-    PdfLayer, PdfLayerReference, PdfResources, Pt, XObject, XObjectRef,
+    PdfLayer, PdfLayerReference, PdfResources, Pt, XObject, XObjectRef, LinkAnnotation, LinkAnnotationRef,
 };
 
 /// PDF page
@@ -141,6 +141,14 @@ impl PdfPage {
     pub fn add_xobject(&mut self, xobj: XObject) -> XObjectRef {
         self.resources.add_xobject(xobj)
     }
+
+    /// __STUB__: Adds a Link Annotation to the pages resources.
+    #[inline]
+    pub fn add_link_annotation(&mut self, annotation: LinkAnnotation) -> LinkAnnotationRef {
+        self.resources.add_link_annotation(annotation)
+    }
+
+    
 }
 
 impl PdfPageReference {

--- a/src/pdf_resources.rs
+++ b/src/pdf_resources.rs
@@ -1,6 +1,7 @@
 use crate::{
-    ExtendedGraphicsState, ExtendedGraphicsStateList, ExtendedGraphicsStateRef, OCGList, OCGRef,
-    Pattern, PatternList, PatternRef, XObject, XObjectList, XObjectRef,
+    ExtendedGraphicsState, ExtendedGraphicsStateList, ExtendedGraphicsStateRef, LinkAnnotation,
+    LinkAnnotationList, LinkAnnotationRef, OCGList, OCGRef, Pattern, PatternList, PatternRef,
+    XObject, XObjectList, XObjectRef,
 };
 use lopdf;
 
@@ -15,6 +16,8 @@ pub struct PdfResources {
     pub graphics_states: ExtendedGraphicsStateList,
     /// Layers / optional content ("Properties") in the resource dictionary
     pub layers: OCGList,
+    /// Link Annotations used in this page
+    pub link_annotations: LinkAnnotationList,
 }
 
 impl PdfResources {
@@ -44,6 +47,12 @@ impl PdfResources {
         self.patterns.add_pattern(pattern)
     }
 
+    /// __STUB__: Adds a link annotation to the resources
+    #[inline]
+    pub fn add_link_annotation(&mut self, link_annotation: LinkAnnotation) -> LinkAnnotationRef {
+        self.link_annotations.add_link_annotation(link_annotation)
+    }
+
     /// See `XObject::Into_with_document`.
     /// The resources also need access to the layers (the optional content groups), this should be a
     /// `Vec<lopdf::Object::Reference>` (to the actual OCG groups, which are added on the document level)
@@ -61,6 +70,7 @@ impl PdfResources {
         let xobjects_dict: lopdf::Dictionary = self.xobjects.into_with_document(doc);
         let patterns_dict: lopdf::Dictionary = self.patterns.into();
         let graphics_state_dict: lopdf::Dictionary = self.graphics_states.into();
+        let annotations_dict: lopdf::Dictionary = self.link_annotations.into();
 
         if !layers.is_empty() {
             for l in layers {
@@ -84,6 +94,10 @@ impl PdfResources {
 
         if !graphics_state_dict.is_empty() {
             dict.set("ExtGState", lopdf::Object::Dictionary(graphics_state_dict));
+        }
+
+        if !annotations_dict.is_empty() {
+            dict.set("Annots", lopdf::Object::Dictionary(annotations_dict))
         }
 
         (dict, ocg_references)

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,0 +1,34 @@
+use crate::{Mm, Point};
+
+#[derive(Debug, Copy, Clone)]
+pub struct Rect {
+    /// x position from the bottom left corner in pt
+    pub ll: Point,
+    /// y position from the bottom left corner in pt
+    pub ur: Point,
+}
+
+impl Rect {
+    /// Create a new point.
+    /// **WARNING: The reference point for a point is the bottom left corner, not the top left**
+    #[inline]
+    pub fn new(llx: Mm, lly: Mm, urx: Mm, ury: Mm) -> Self {
+        Self {
+            ll: Point {
+                x: llx.into(),
+                y: lly.into(),
+            },
+            ur: Point {
+                x: urx.into(),
+                y: ury.into(),
+            },
+        }
+    }
+}
+
+impl PartialEq for Rect {
+    // custom compare function because of floating point inaccuracy
+    fn eq(&self, other: &Rect) -> bool {
+        self.ll == other.ll && self.ur == other.ur
+    }
+}


### PR DESCRIPTION
Mentioned in [this issue](https://github.com/fschutt/printpdf/issues/148), the crate previously didn't have a way of adding hyperlinks. This PR introduces Link Annotations(can be found in [page 394 at Adobe PDF 1.7 format](https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf)) that allows for selecting a rectangle within the page, and use it as a URI. Although it is possible to have a more general structure that supports all types of annotations, I believe that would take an enormous amount of time with little benefits in return. I will be expecting your comments.