### PR TITLE
add feature to make use of js-sys optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ usvg = { version = "0.19.0", optional = true }
 allsorts = { version = "0.14", optional = true, default-features = false, features = ["flate2_rust"]  }
 
 [features]
-default = []
+default = ["js-sys"]
 # do not compress PDF streams, useful for debugging
 less-optimization = []
 # enables logging
@@ -58,12 +58,14 @@ svg = ["svg2pdf", "usvg", "pdf-writer"]
 font_subsetting = ["dep:allsorts"]
 # enables annotations
 annotations = ["pdf-writer"]
+# enables js-sys features on wasm
+js-sys = ["dep:js-sys"]
 
 [package.metadata.docs.rs]
 all-features = true
 
 [target.'cfg(all(target_arch="wasm32",target_os="unknown"))'.dependencies]
-js-sys = "0.3.40"
+js-sys = { version = "0.3.40", optional = true }
 
 [badges]
 travis-ci = { repository = "fschutt/printpdf" }

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,11 +1,16 @@
 /// wasm32-unknown-unknown polyfill
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(all(feature = "js-sys", target_arch = "wasm32", target_os = "unknown"))]
 pub use self::js_sys_date::OffsetDateTime;
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
+
+#[cfg(not(feature = "js-sys"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+pub use self::unix_epoch_stub_date::OffsetDateTime;
+
+#[cfg(not(any(target_arch = "wasm32", target_os = "unknown")))]
 pub use time::OffsetDateTime;
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(all(feature = "js-sys", target_arch = "wasm32", target_os = "unknown"))]
 mod js_sys_date {
     use js_sys::Date;
     #[derive(Debug, Clone)]
@@ -57,6 +62,60 @@ mod js_sys_date {
         #[inline(always)]
         pub fn second(&self) -> u32 {
             self.0.get_seconds()
+        }
+    }
+}
+
+#[cfg(not(feature = "js-sys"))]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+mod unix_epoch_stub_date {
+    #[derive(Debug, Clone)]
+    pub struct OffsetDateTime;
+    impl OffsetDateTime {
+        #[inline(always)]
+        pub fn now_utc() -> Self {
+            OffsetDateTime
+        }
+
+        #[inline(always)]
+        pub fn now() -> Self {
+            OffsetDateTime
+        }
+
+        #[inline(always)]
+        pub fn format(&self, format: impl ToString) -> String {
+            // TODO
+            "".into()
+        }
+
+        #[inline(always)]
+        pub fn year(&self) -> u32 {
+            1970
+        }
+
+        #[inline(always)]
+        pub fn month(&self) -> u32 {
+            1
+        }
+
+        #[inline(always)]
+        pub fn day(&self) -> u32 {
+            1
+        }
+
+        #[inline(always)]
+        pub fn hour(&self) -> u32 {
+            0
+        }
+
+        #[inline(always)]
+        pub fn minute(&self) -> u32 {
+            0
+        }
+
+        #[inline(always)]
+        pub fn second(&self) -> u32 {
+            0
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,7 +317,7 @@ fn main() {
 pub extern crate log;
 #[cfg(feature = "embedded_images")]
 pub extern crate image as image_crate;
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(all(feature = "js-sys", target_arch = "wasm32", target_os = "unknown"))]
 extern crate js_sys;
 
 pub use lopdf;


### PR DESCRIPTION
Resolves #157.  This doesn't add a feature for reproducible output on all platforms, it's strictly for disabling `js-sys` on wasm.