### PR TITLE
Implement adding a rectangle to a pdf layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,7 @@ required-features = []
 [[example]]
 name = "hyperlink"
 required-features = ["annotations"]
+
+[[example]]
+name = "rect"
+required-features = []

--- a/examples/circle.rs
+++ b/examples/circle.rs
@@ -1,5 +1,6 @@
 extern crate printpdf;
 
+use printpdf::path::{PaintMode, WindingOrder};
 use printpdf::*;
 use std::fs::File;
 use std::io::BufWriter;
@@ -19,7 +20,7 @@ fn main() {
             calculate_points_for_circle(radius_1, offset_x, offset_y),
             calculate_points_for_circle(radius_2, offset_x, offset_y), // hole
         ],
-        mode: PolygonMode::FillStroke,
+        mode: PaintMode::FillStroke,
         winding_order: WindingOrder::EvenOdd,
     };
 
@@ -31,8 +32,13 @@ fn main() {
     let offset_y_rect = Pt(5.0);
 
     let line = Polygon {
-        rings: vec![calculate_points_for_rect(scale_x_rect, scale_y_rect, offset_x_rect, offset_y_rect)],
-        mode: PolygonMode::FillStroke,
+        rings: vec![calculate_points_for_rect(
+            scale_x_rect,
+            scale_y_rect,
+            offset_x_rect,
+            offset_y_rect,
+        )],
+        mode: PaintMode::FillStroke,
         winding_order: WindingOrder::NonZero,
     };
 

--- a/examples/rect.rs
+++ b/examples/rect.rs
@@ -1,0 +1,30 @@
+extern crate printpdf;
+
+use printpdf::path::{PaintMode, WindingOrder};
+use printpdf::*;
+use std::fs::File;
+use std::io::BufWriter;
+
+fn main() {
+    let (doc, page1, layer1) =
+        PdfDocument::new("printpdf rect test", Mm(210.0), Mm(297.0), "Layer 1");
+    let current_layer = doc.get_page(page1).get_layer(layer1);
+
+    let rect = Rect::new(Mm(30.), Mm(250.), Mm(200.), Mm(290.));
+
+    current_layer.add_rect(rect);
+
+    let rect = Rect::new(Mm(50.), Mm(180.), Mm(120.), Mm(290.))
+        .with_mode(PaintMode::Clip)
+        .with_winding(WindingOrder::EvenOdd);
+
+    current_layer.add_rect(rect);
+
+    let mut font_reader =
+        std::io::Cursor::new(include_bytes!("../assets/fonts/RobotoMedium.ttf").as_ref());
+    let font = doc.add_external_font(&mut font_reader).unwrap();
+
+    current_layer.use_text("hello world", 100.0, Mm(10.0), Mm(200.0), &font);
+    doc.save(&mut BufWriter::new(File::create("test_rect.pdf").unwrap()))
+        .unwrap();
+}

--- a/examples/shape.rs
+++ b/examples/shape.rs
@@ -1,5 +1,6 @@
 extern crate printpdf;
 
+use printpdf::path::{PaintMode, WindingOrder};
 use printpdf::*;
 use std::fs::File;
 use std::io::BufWriter;
@@ -42,14 +43,12 @@ fn main() {
     // Note: Line is invisible by default, the previous method of
     // constructing a line is recommended!
     let mut line2 = Polygon {
-        rings: vec![
-            vec![
-                (Point::new(Mm(150.0), Mm(150.0)), false),
-                (Point::new(Mm(150.0), Mm(250.0)), false),
-                (Point::new(Mm(350.0), Mm(250.0)), false),
-            ]
-        ],
-        mode: PolygonMode::FillStroke,
+        rings: vec![vec![
+            (Point::new(Mm(150.0), Mm(150.0)), false),
+            (Point::new(Mm(150.0), Mm(250.0)), false),
+            (Point::new(Mm(350.0), Mm(250.0)), false),
+        ]],
+        mode: PaintMode::FillStroke,
         winding_order: WindingOrder::NonZero,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //!
 //! ```rust
 //! use printpdf::*;
+//! use printpdf::path::{PaintMode, WindingOrder};
 //! use std::fs::File;
 //! use std::io::BufWriter;
 //! use std::iter::FromIterator;
@@ -59,7 +60,7 @@
 //!
 //! let line1 = Polygon {
 //!     rings: vec![points1],
-//!     mode: PolygonMode::FillStroke,
+//!     mode: PaintMode::FillStroke,
 //!     winding_order: WindingOrder::NonZero,
 //! };
 //!
@@ -93,7 +94,7 @@
 //!     (Point::new(Mm(150.0), Mm(150.0)), false),
 //!     (Point::new(Mm(150.0), Mm(250.0)), false),
 //!     (Point::new(Mm(350.0), Mm(250.0)), false)]);
-//! 
+//!
 //! // draw second line
 //! current_layer.add_line(line2);
 //! ```
@@ -335,6 +336,7 @@ pub mod indices;
 pub mod line;
 pub mod link_annotation;
 pub mod ocg;
+pub mod path;
 pub mod pattern;
 pub mod pdf_conformance;
 pub mod pdf_document;
@@ -345,13 +347,13 @@ pub mod pdf_resources;
 pub mod point;
 pub mod rectangle;
 pub mod scale;
+#[cfg(feature = "font_subsetting")]
+pub(crate) mod subsetting;
 #[cfg(feature = "svg")]
 pub mod svg;
 pub mod utils;
 pub mod xmp_metadata;
 pub mod xobject;
-#[cfg(feature = "font_subsetting")]
-pub(crate) mod subsetting;
 
 pub(crate) mod glob_defines {
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,8 +1,11 @@
 //! Utilities to work with path objects.
 
-use crate::glob_defines::{
-    OP_PATH_CONST_CLIP_EO, OP_PATH_CONST_CLIP_NZ, OP_PATH_PAINT_FILL_EO, OP_PATH_PAINT_FILL_NZ,
-    OP_PATH_PAINT_FILL_STROKE_CLOSE_EO, OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
+use crate::{
+    glob_defines::{
+        OP_PATH_CONST_CLIP_EO, OP_PATH_CONST_CLIP_NZ, OP_PATH_PAINT_FILL_EO, OP_PATH_PAINT_FILL_NZ,
+        OP_PATH_PAINT_FILL_STROKE_CLOSE_EO, OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
+    },
+    OP_PATH_PAINT_FILL_STROKE_EO, OP_PATH_PAINT_FILL_STROKE_NZ,
 };
 
 /// The rule to use in filling/clipping paint operations.
@@ -65,6 +68,15 @@ impl WindingOrder {
         match self {
             WindingOrder::NonZero => OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
             WindingOrder::EvenOdd => OP_PATH_PAINT_FILL_STROKE_CLOSE_EO,
+        }
+    }
+
+    /// Gets the operator for a fill and stroke painting operation.
+    #[must_use]
+    pub fn get_fill_stroke_op(&self) -> &'static str {
+        match self {
+            WindingOrder::NonZero => OP_PATH_PAINT_FILL_STROKE_NZ,
+            WindingOrder::EvenOdd => OP_PATH_PAINT_FILL_STROKE_EO,
         }
     }
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,14 +5,43 @@ use crate::glob_defines::{
     OP_PATH_PAINT_FILL_STROKE_CLOSE_EO, OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
 };
 
+/// The rule to use in filling/clipping paint operations.
+///
+/// This is meaningful in the following cases:
+///
+/// - When a path uses one of the _fill_ paint operations, this will determine the rule used to
+/// fill the paths.
+/// - When a path uses a [clip] painting mode, this will determine the rule used to limit the
+/// regions of the page affected by painting operators.
+///
+/// Most of the time, `NonZero` is the appropriate option.
+///
+/// [clip]: PaintMode::Clip
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WindingOrder {
+    /// Make any filling or clipping paint operators follow the _even-odd rule_.
+    ///
+    /// This rule determines whether a point is inside a path by drawing a ray from that point in
+    /// any direction and simply counting the number of path segments that cross the ray,
+    /// regardless of direction. If this number is odd, the point is inside; if even, the point is
+    /// outside. This yields the same results as the nonzero winding number rule for paths with
+    /// simple shapes, but produces different results for more complex shapes.
     EvenOdd,
+
+    /// Make any filling or clipping paint operators follow the _nonzero rule_.
+    ///
+    /// This rule determines whether a given point is inside a path by conceptually drawing a ray
+    /// from that point to infinity in any direction and then examining the places where a segment
+    /// of the path crosses the ray. Starting with a count of 0, the rule adds 1 each time a path
+    /// segment crosses the ray from left to right and subtracts 1 each time a segment crosses from
+    /// right to left. After counting all the crossings, if the result is 0, the point is outside
+    /// the path; otherwise, it is inside.
     #[default]
     NonZero,
 }
 
 impl WindingOrder {
+    /// Gets the operator for a clip paint operation.
     #[must_use]
     pub fn get_clip_op(&self) -> &'static str {
         match self {
@@ -21,6 +50,7 @@ impl WindingOrder {
         }
     }
 
+    /// Gets the operator for a fill paint operation.
     #[must_use]
     pub fn get_fill_op(&self) -> &'static str {
         match self {
@@ -29,6 +59,7 @@ impl WindingOrder {
         }
     }
 
+    /// Gets the operator for a close, fill and stroke painting operation.
     #[must_use]
     pub fn get_fill_stroke_close_op(&self) -> &'static str {
         match self {
@@ -38,11 +69,22 @@ impl WindingOrder {
     }
 }
 
+/// The path-painting mode for a path.
 #[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PaintMode {
+    /// Set the path in clipping mode instead of painting it.
+    ///
+    /// The path is not being drawing, but it will be used for clipping operations instead. The
+    /// rule for clipping are determined by the value [`WindingOrder`] associated to the path.
     Clip,
+
+    /// Fill the path.
     #[default]
     Fill,
+
+    /// Paint a line along the path.
     Stroke,
+
+    /// Fill the path and paint a line along it.
     FillStroke,
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,0 +1,55 @@
+//! Utilities to work with path objects.
+
+use crate::glob_defines::{
+    OP_PATH_CONST_CLIP_EO, OP_PATH_CONST_CLIP_NZ, OP_PATH_PAINT_FILL_EO, OP_PATH_PAINT_FILL_NZ,
+    OP_PATH_PAINT_FILL_STROKE_CLOSE_EO, OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub enum WindingOrder {
+    EvenOdd,
+    NonZero,
+}
+
+impl Default for WindingOrder {
+    fn default() -> Self {
+        WindingOrder::NonZero
+    }
+}
+
+impl WindingOrder {
+    pub fn get_clip_op(&self) -> &'static str {
+        match self {
+            WindingOrder::NonZero => OP_PATH_CONST_CLIP_NZ,
+            WindingOrder::EvenOdd => OP_PATH_CONST_CLIP_EO,
+        }
+    }
+
+    pub fn get_fill_op(&self) -> &'static str {
+        match self {
+            WindingOrder::NonZero => OP_PATH_PAINT_FILL_NZ,
+            WindingOrder::EvenOdd => OP_PATH_PAINT_FILL_EO,
+        }
+    }
+
+    pub fn get_fill_stroke_close_op(&self) -> &'static str {
+        match self {
+            WindingOrder::NonZero => OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
+            WindingOrder::EvenOdd => OP_PATH_PAINT_FILL_STROKE_CLOSE_EO,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum PaintMode {
+    Clip,
+    Fill,
+    Stroke,
+    FillStroke,
+}
+
+impl Default for PaintMode {
+    fn default() -> PaintMode {
+        PaintMode::Fill
+    }
+}

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,7 +5,7 @@ use crate::glob_defines::{
     OP_PATH_PAINT_FILL_STROKE_CLOSE_EO, OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
 };
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WindingOrder {
     EvenOdd,
     #[default]
@@ -38,7 +38,7 @@ impl WindingOrder {
     }
 }
 
-#[derive(Debug, Default, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum PaintMode {
     Clip,
     #[default]

--- a/src/path.rs
+++ b/src/path.rs
@@ -5,19 +5,15 @@ use crate::glob_defines::{
     OP_PATH_PAINT_FILL_STROKE_CLOSE_EO, OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
 };
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy)]
 pub enum WindingOrder {
     EvenOdd,
+    #[default]
     NonZero,
 }
 
-impl Default for WindingOrder {
-    fn default() -> Self {
-        WindingOrder::NonZero
-    }
-}
-
 impl WindingOrder {
+    #[must_use]
     pub fn get_clip_op(&self) -> &'static str {
         match self {
             WindingOrder::NonZero => OP_PATH_CONST_CLIP_NZ,
@@ -25,6 +21,7 @@ impl WindingOrder {
         }
     }
 
+    #[must_use]
     pub fn get_fill_op(&self) -> &'static str {
         match self {
             WindingOrder::NonZero => OP_PATH_PAINT_FILL_NZ,
@@ -32,6 +29,7 @@ impl WindingOrder {
         }
     }
 
+    #[must_use]
     pub fn get_fill_stroke_close_op(&self) -> &'static str {
         match self {
             WindingOrder::NonZero => OP_PATH_PAINT_FILL_STROKE_CLOSE_NZ,
@@ -40,16 +38,11 @@ impl WindingOrder {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq)]
 pub enum PaintMode {
     Clip,
+    #[default]
     Fill,
     Stroke,
     FillStroke,
-}
-
-impl Default for PaintMode {
-    fn default() -> PaintMode {
-        PaintMode::Fill
-    }
 }

--- a/src/pdf_layer.rs
+++ b/src/pdf_layer.rs
@@ -5,8 +5,8 @@ use crate::indices::{PdfLayerIndex, PdfPageIndex};
 use crate::{
     BlendMode, Color, CurTransMat, ExtendedGraphicsStateBuilder, Font, ImageXObject,
     IndirectFontRef, Line, LineCapStyle, LineDashPattern, LineJoinStyle, LinkAnnotation,
-    LinkAnnotationRef, Mm, PdfColor, PdfDocument, Pt, TextMatrix, TextRenderingMode, XObject,
-    XObjectRef, Polygon,
+    LinkAnnotationRef, Mm, PdfColor, PdfDocument, Polygon, Pt, Rect, TextMatrix, TextRenderingMode,
+    XObject, XObjectRef,
 };
 use lopdf::content::Operation;
 use std::cell::RefCell;
@@ -548,5 +548,11 @@ impl PdfLayerReference {
                 vec![lopdf::Object::Name(name.as_bytes().to_vec())],
             ));
     }
-}
 
+    /// Add a rectangle to the layer.
+    pub fn add_rect(&self, rect: Rect) {
+        for op in rect.into_stream_op() {
+            self.add_operation(op);
+        }
+    }
+}

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -7,14 +7,17 @@ use crate::{Mm, Point};
 /// This can be used to paint rectangles or to clip other paths.
 #[derive(Debug, Copy, Clone)]
 pub struct Rect {
-    /// x position from the bottom left corner in pt
+    /// Position of the lower left point of the rectangle, relative to the bottom left corner of
+    /// the PDF page in pt.
     pub ll: Point,
-    /// y position from the bottom left corner in pt
+    /// Position of the upper right point of the rectangle, relative to the bottom left corner of
+    /// the PDF page in pt.
     pub ur: Point,
 }
 
 impl Rect {
     /// Create a new point.
+    ///
     /// **WARNING: The reference point for a point is the bottom left corner, not the top left**
     #[inline]
     pub fn new(llx: Mm, lly: Mm, urx: Mm, ury: Mm) -> Self {

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,6 +1,9 @@
 //! Utilities for rectangle paths.
 
-use crate::{Mm, Point};
+use crate::{
+    path::{PaintMode, WindingOrder},
+    Mm, Point, OP_PATH_CONST_RECT, OP_PATH_PAINT_END, OP_PATH_PAINT_STROKE,
+};
 
 /// A helper struct to insert rectangular shapes into a PDF.
 ///
@@ -13,6 +16,10 @@ pub struct Rect {
     /// Position of the upper right point of the rectangle, relative to the bottom left corner of
     /// the PDF page in pt.
     pub ur: Point,
+    /// The paint mode of the rectangle.
+    pub mode: PaintMode,
+    /// The path-painting/clipping path operator.
+    pub winding: WindingOrder,
 }
 
 impl Rect {
@@ -30,6 +37,58 @@ impl Rect {
                 x: urx.into(),
                 y: ury.into(),
             },
+            mode: PaintMode::default(),
+            winding: WindingOrder::default(),
+        }
+    }
+
+    /// Returns a new `Rect` with the specified `mode`.
+    #[inline]
+    #[must_use]
+    pub fn with_mode(mut self, mode: PaintMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
+    /// Returns a new `Rect` with the specified `winding`.
+    #[inline]
+    #[must_use]
+    pub fn with_winding(mut self, winding: WindingOrder) -> Self {
+        self.winding = winding;
+        self
+    }
+
+    /// Transform the `Rect` into a `Vec` of PDF [`Operation`]s.
+    ///
+    /// [`Operation`]: lopdf::content::Operation
+    #[must_use]
+    pub fn into_stream_op(self) -> Vec<lopdf::content::Operation> {
+        use lopdf::content::Operation;
+
+        let width = self.ur.x - self.ll.x;
+        let height = self.ur.y - self.ll.y;
+
+        let rect_op = Operation::new(
+            OP_PATH_CONST_RECT,
+            vec![
+                self.ll.x.into(),
+                self.ll.y.into(),
+                width.into(),
+                height.into(),
+            ],
+        );
+
+        let paint_op = match self.mode {
+            PaintMode::Clip => Operation::new(self.winding.get_clip_op(), vec![]),
+            PaintMode::Fill => Operation::new(self.winding.get_fill_op(), vec![]),
+            PaintMode::Stroke => Operation::new(OP_PATH_PAINT_STROKE, vec![]),
+            PaintMode::FillStroke => Operation::new(self.winding.get_fill_stroke_op(), vec![]),
+        };
+
+        if matches!(self.mode, PaintMode::Clip) {
+            vec![rect_op, paint_op, Operation::new(OP_PATH_PAINT_END, vec![])]
+        } else {
+            vec![rect_op, paint_op]
         }
     }
 }

--- a/src/rectangle.rs
+++ b/src/rectangle.rs
@@ -1,5 +1,10 @@
+//! Utilities for rectangle paths.
+
 use crate::{Mm, Point};
 
+/// A helper struct to insert rectangular shapes into a PDF.
+///
+/// This can be used to paint rectangles or to clip other paths.
 #[derive(Debug, Copy, Clone)]
 pub struct Rect {
     /// x position from the bottom left corner in pt


### PR DESCRIPTION
This should improve the support to writing PDFs towards two directions:

1. The ability of stroke/fill rectangles
2. The possibility of using simple clipping operations based on rectangles

The changes should be pretty straightforward, and I also added a few changes/fixes to the doc. Still, there are a couple of points I would like to discuss:

- I added `Mode` and `Winding` specifically for the `rectangle` module. However, we could consider to unify those with the one available inside the `line` module. The `Winding` enum cannot actually be any different, I am a bit unsure about the `Mode` because I don't have a clear view about other possibilities (i.e: is there a paint mode that we would like to add in the future that makes sense for a `Rect` but not for a `Polygon` or vice versa?)
- While writing the implementation for `into_stream_op`, I noticed that `Polygon` [adds a __paint end__](https://github.com/fschutt/printpdf/blob/cec012ad726344c31f715ab8c939ad0c11c7fcaf/src/line.rs#L291) even after a stroke/fill. AFAIK (reading from the PDF specs) this should be only necessary if a _path-painting operator_ has not been used -- and strokes/fills are actually _path-painting operators_. I am pointing this out just because if I am right, I don't think it should be an actual problem (probably any pdf reader does not have any trouble ignoring the `n` operator), but if I am wrong I should change the implementation for `Rect`, because I only add the _path end operator_ only in clipping mode.

Let me know what do you think, and feel free to give any suggestion I could improve the code or the doc.

Last but not least: this is a breaking change because of the new `Rect::mode` field (and [cargo-semver-checks](https://github.com/obi1kenobi/cargo-semver-checks) confirms that).

CC @paolobarbolini