### PR TITLE
fix: fix feature = "cargo-clippy" deprecation

### DIFF
--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -1,5 +1,5 @@
 // clippy lints when serializing PDF strings, in this case its wrong
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::string_lit_as_bytes))]
+#![allow(clippy::string_lit_as_bytes)]
 
 use crate::OffsetDateTime;
 #[cfg(feature = "embedded_images")]


### PR DESCRIPTION
https://blog.rust-lang.org/2024/02/28/Clippy-deprecating-feature-cargo-clippy.html