### PR TITLE
Fix transparency of non square images.

### DIFF
--- a/src/xobject.rs
+++ b/src/xobject.rs
@@ -264,7 +264,7 @@ impl From<ImageXObject> for lopdf::Stream {
             // This is using the "Soft-Mask Images" approach. See page 447 of the adobe PDF 1.4 reference
             XObject::Image(ImageXObject {
                 width: img.width,
-                height: img.width,
+                height: img.height,
                 color_space: ColorSpace::Greyscale,
                 bits_per_component: ColorBits::Bit8,
                 interpolate: false,


### PR DESCRIPTION
Hello!

PR #158, added support for transparent images, it works great but only for square images.

This PR fixes that, I think the bug is quite obvious when printed in red and green.