### PR TITLE
CJK fonts rendering works as expected

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -422,7 +422,10 @@ impl ParsedFont {
         for gid in glyph_ids.keys() {
             let (width, _) = match self.get_glyph_size(*gid) {
                 Some(s) => s,
-                None => continue,
+                None => match self.get_space_width() {
+                    Some(w) => (w as i32, 0),
+                    None => (0, 0),
+                },
             };
 
             if *gid == current_high_gid {
@@ -764,7 +767,7 @@ impl ParsedFont {
     // get the x and y size of a glyph (unscaled units)
     pub fn get_glyph_size(&self, glyph_index: u16) -> Option<(i32, i32)> {
         let g = self.glyph_records_decoded.get(&glyph_index)?;
-        let glyph_width = g.bounding_box.max_x as i32 - g.bounding_box.min_x as i32; // width
+        let glyph_width = g.horz_advance as i32;
         let glyph_height = g.bounding_box.max_y as i32 - g.bounding_box.min_y as i32; // height
         Some((glyph_width, glyph_height))
     }


### PR DESCRIPTION
Hi there, thank you for the great library.

Recently, I started to use this library and got stuck at #201, but as a Japanese user, I could not overlook this bug and continue using it. After playing with the code, I think I found a quick remedy and sent this pull request.

As far as I have tested, it looks working well. However, I am not an expert on PDFs, so I might be doing something wrong. I do not mind at all if this is not merged, but please take a look. 

Thanks.

- The rendered result 
![Screenshot 2025-02-02 at 23 50 31](https://github.com/user-attachments/assets/fbeb2aad-8c46-4ef4-bad9-f1f2d41ff6d1)

- Same text in Adobe Illustrator
![Screenshot 2025-02-02 at 23 51 06](https://github.com/user-attachments/assets/bd63512e-f1f0-4797-802b-519514c5b899)


