### PR TITLE
Set FontBBox origin to zero

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -998,7 +998,7 @@ fn add_font_to_pdf(
                             "FontBBox",
                             Array(vec![
                                 Integer(0),
-                                Integer(prepared.max_height),
+                                Integer(0),
                                 Integer(prepared.total_width),
                                 Integer(prepared.max_height),
                             ]),


### PR DESCRIPTION
Hi @fschutt  again! 

While testing CJK fonts, I noticed that Adobe Acrobat Reader displays an error message, although no errors occur in web browsers or macOS Preview app.

<img width="591" alt="Screenshot 2025-02-04 at 8 49 20" src="https://github.com/user-attachments/assets/f46b39c1-089e-47bd-9073-5e7f7413d56f" />

This fix seems to solve the issue, at least the above error has gone. However, I'm not sure if always setting the origin to (0, 0) is valid for all fonts.