### PR TITLE
Allow writing directly into anything that implements `Write`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -383,10 +383,15 @@ impl PdfDocument {
         self.pages.append(&mut pages);
         self
     }
-
-		pub fn save_writer<W: std::io::Write>(&self, w: &mut W, opts: &PdfSaveOptions, warnings: &mut Vec<PdfWarnMsg>) {
-			self::serialize::serialize_pdf(self, opts, w, warnings);
-		}
+    /// Serializes the PDF document and writes it to a `writer`
+    pub fn save_writer<W: std::io::Write>(
+        &self,
+        w: &mut W,
+        opts: &PdfSaveOptions,
+        warnings: &mut Vec<PdfWarnMsg>,
+    ) {
+        self::serialize::serialize_pdf(self, opts, w, warnings);
+    }
     /// Serializes the PDF document to bytes
     pub fn save(&self, opts: &PdfSaveOptions, warnings: &mut Vec<PdfWarnMsg>) -> Vec<u8> {
         self::serialize::serialize_pdf_into_bytes(self, opts, warnings)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,6 +384,9 @@ impl PdfDocument {
         self
     }
 
+		pub fn save_writer<W: std::io::Write>(&self, w: &mut W, opts: &PdfSaveOptions, warnings: &mut Vec<PdfWarnMsg>) {
+			self::serialize::serialize_pdf(self, opts, w, warnings);
+		}
     /// Serializes the PDF document to bytes
     pub fn save(&self, opts: &PdfSaveOptions, warnings: &mut Vec<PdfWarnMsg>) -> Vec<u8> {
         self::serialize::serialize_pdf_into_bytes(self, opts, warnings)


### PR DESCRIPTION
This means that the Pdf doesn't need to be serialized into bytes first, which takes time and uses more memory for large PDFs.

It also provides a slight performance improvement when writing all PDFs directly to a file:
![image](https://github.com/user-attachments/assets/83b3cf6b-1705-466a-bcad-4e39f93b072c)
(Top is before this change, and bottom is after)

Time shown is in microseconds. I ran this a few times to confirm that it wasn't just a fluke, and (although they're not great benchmarks) show that at least there is no performance regression.

Here is an example of this change being used to actually write a PDF:
https://github.com/Tommypop2/code-to-pdf/commit/ac526a37d48ad9d65514614b4ea772c169886b14