### PR TITLE
Fix bookmarks

### DIFF
--- a/examples/bookmarks.rs
+++ b/examples/bookmarks.rs
@@ -94,7 +94,7 @@ fn main() {
             link: LinkAnnotation::new(
                 Rect {
                     x: Pt(100.0),
-                    y: Pt(200.0),
+                    y: Pt(170.0),
                     width: Pt(200.0),
                     height: Pt(30.0),
                 },
@@ -209,7 +209,7 @@ fn main() {
             link: LinkAnnotation::new(
                 Rect {
                     x: Pt(100.0),
-                    y: Pt(110.0),
+                    y: Pt(80.0),
                     width: Pt(200.0),
                     height: Pt(30.0),
                 },
@@ -355,7 +355,7 @@ fn main() {
             link: LinkAnnotation::new(
                 Rect {
                     x: Pt(100.0),
-                    y: Pt(200.0),
+                    y: Pt(170.0),
                     width: Pt(200.0),
                     height: Pt(30.0),
                 },
@@ -447,7 +447,7 @@ fn main() {
             link: LinkAnnotation::new(
                 Rect {
                     x: Pt(100.0),
-                    y: Pt(150.0),
+                    y: Pt(120.0),
                     width: Pt(200.0),
                     height: Pt(30.0),
                 },
@@ -598,7 +598,7 @@ fn main() {
             link: LinkAnnotation::new(
                 Rect {
                     x: Pt(100.0),
-                    y: Pt(200.0),
+                    y: Pt(170.0),
                     width: Pt(200.0),
                     height: Pt(30.0),
                 },
@@ -688,7 +688,7 @@ fn main() {
             link: LinkAnnotation::new(
                 Rect {
                     x: Pt(100.0),
-                    y: Pt(150.0),
+                    y: Pt(120.0),
                     width: Pt(200.0),
                     height: Pt(30.0),
                 },


### PR DESCRIPTION
Hello @fschutt, 

Thanks for the crate first. I was using the version 0.8.2 and bookmarks seems to not work. After a bit of debugging, it seems that there is a TODO in the serialize.rs file. 

I looked into https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/pdfreference1.3.pdf and it seems that Annots needs to be part of the Page definition rather than a Resource. 

The fix I did just change where the Annots are put during the serialization. Maybe these one should not be part of the Operations at all and be added to the page somehow ?