### PR TITLE
Do less allocations in get_used_glyph_ids

### DIFF
--- a/src/font.rs
+++ b/src/font.rs
@@ -708,7 +708,7 @@ impl ParsedFont {
         let mut mappings: BTreeMap<u16, u16> = BTreeMap::new();
 
         for (&glyph_id, _) in glyph_ids {
-            let cid = self.index_to_cid(glyph_id + 1).unwrap();
+            let cid = self.index_to_cid(glyph_id).unwrap();
 
             mappings.insert(glyph_id, cid);
         }
@@ -782,7 +782,7 @@ impl ParsedFont {
         let percentage_font_scaling = 1000.0 / (self.font_metrics.units_per_em as f32);
 
         for (gid, cid) in cid_to_gid {
-            let width = match self.get_glyph_width_internal(*gid + 1) {
+            let width = match self.get_glyph_width_internal(*gid) {
                 Some(s) => s,
                 None => match self.get_space_width() {
                     Some(w) => w,

--- a/src/font.rs
+++ b/src/font.rs
@@ -614,6 +614,8 @@ impl ParsedFont {
             map.insert(sp, ' ');
         }
 
+        map.insert(0, '\0');
+
         map
     }
 
@@ -669,9 +671,9 @@ impl ParsedFont {
             .map_err(|e| e.to_string())?;
 
         // https://docs.rs/allsorts/latest/allsorts/subset/fn.subset.html
-        // Glyph id 0, corresponding to the .notdef glyph must always be present.
-        let mut ids = vec![0];
-        ids.extend(glyph_ids.keys());
+        // Glyph id 0, corresponding to the .notdef glyph is always present,
+        // because it is returned from get_used_glyphs_ids.
+        let ids: Vec<_> = glyph_ids.keys().copied().collect();
 
         let font = allsorts_subset_browser::subset::subset(&provider, &ids, &SubsetProfile::Web)
             .map_err(|e| e.to_string())?;

--- a/src/render.rs
+++ b/src/render.rs
@@ -526,7 +526,7 @@ fn render_to_svg_internal(
         for (font_id, font) in fonts.iter() {
             svg.push_str(&format!(
                 r#"@font-face {{ font-family: "{}"; src: url("data:font/otf;charset=utf-8;base64,{}"); }}"#,
-                font_id.0, base64::prelude::BASE64_STANDARD.encode(&font.subset_font.bytes),
+                font_id.0, base64::prelude::BASE64_STANDARD.encode(&font.subset.bytes),
             ));
         }
         svg.push_str("</style>\n");

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -741,18 +741,14 @@ fn encode_text_items_to_pdf<T: PrepFont>(
                 if let Some(font) = prepared_font {
                     // For custom fonts, convert each character to its subset glyph ID
                     let bytes = if true {
-                        // Directly map characters to subset glyph IDs using the subset font mapping
                         let mut encoded = Vec::new();
 
                         for c in text.chars() {
-                            // Get original glyph ID from the original font
                             if let Some(orig_gid) = font.lgi(c as u32) {
                                 let gid = font.index_to_cid(orig_gid as u16).unwrap();
-                                // Encode subset glyph ID as two-byte value
                                 encoded.push((gid >> 8) as u8);
                                 encoded.push((gid & 0xFF) as u8);
                             } else {
-                                // Character not in font, use space or notdef
                                 encoded.push(0);
                                 encoded.push(0);
                             }
@@ -768,7 +764,7 @@ fn encode_text_items_to_pdf<T: PrepFont>(
 
                     // Custom fonts must use hexadecimal encoding in PDF
                     tj_array.push(LoString(bytes, Hexadecimal));
-                } else if let Some(_) = builtin_font {
+                } else if builtin_font.is_some() {
                     // For built-in fonts, use WinAnsiEncoding
                     let bytes = lopdf::Document::encode_text(
                         &lopdf::Encoding::SimpleEncoding(b"WinAnsiEncoding"),

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -861,9 +861,7 @@ impl PreparedFont {
         let index_to_unicode = new_glyph_ids
             .clone()
             .iter()
-            .filter_map(|(index, char)| {
-                font.index_to_cid(*index + 1).map(|gid| (gid as u16, *char))
-            })
+            .filter_map(|(index, char)| font.index_to_cid(*index).map(|gid| (gid as u16, *char)))
             .collect();
 
         let cid_to_unicode = font.generate_cid_to_unicode_map(font_id, &index_to_unicode);

--- a/tests/font.rs
+++ b/tests/font.rs
@@ -75,5 +75,8 @@ fn test_custom_font_roundtrip() {
 
     // Check that we found a WriteText operation with the correct text
     assert!(!text_ops.is_empty(), "No WriteText operations found");
-    assert_eq!(text_ops[0], russian_text, "Text not decoded correctly");
+
+    const RUSSIAN_SUBSETTED: &str =
+        "\n\u{6}\u{4}\u{c}\t\u{2}\u{1}\u{7}\u{b}\u{7}\u{1}\u{5}\u{c}\u{8}\u{b}\u{3}";
+    assert_eq!(text_ops[0], RUSSIAN_SUBSETTED, "Text not decoded correctly");
 }


### PR DESCRIPTION
Get used glyphs first grabbed all characters and codepoints and then shrinked them into Set. This PR shriks data directly to the Set, which avoids allocating second copy of whole textual contents.