### PR TITLE
Correct image optimisation default quality value

### DIFF
--- a/src/image.rs
+++ b/src/image.rs
@@ -45,7 +45,7 @@ pub struct ImageOptimizationOptions {
 }
 
 const fn default_quality() -> Option<f32> {
-    Some(85.0)
+    Some(0.85)
 }
 
 fn default_max_img_size() -> Option<String> {


### PR DESCRIPTION
This value is [documented](https://github.com/fschutt/printpdf/blob/abce61fcd8313999f19c0e3a14a26742dfc101ec/src/image.rs#L15) to be between `0.0` and `1.0`.

The default value in `default_quality()` was set to 85.0, which is presumably interpreted as 1.0 (this is what I see in my testing)

I tested with various values of quality > 1 and found that the size of the resulting PDF was identical, so the documented range seems to be correct