### PR TITLE
Fix: Correct Rect to_polygon coordinate calculation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,3 @@ required-features = []
 [[example]]
 name = "otf-font"
 required-features = []
-
-[[example]]
-name = "test_rect"
-required-features = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,3 +121,7 @@ required-features = []
 [[example]]
 name = "otf-font"
 required-features = []
+
+[[example]]
+name = "test_rect"
+required-features = []

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -88,8 +88,8 @@ impl Rect {
     }
 
     fn gen_points(&self) -> Vec<LinePoint> {
-        let top = self.y;
-        let bottom = Pt(self.y.0 - self.height.0);
+        let top = Pt(self.y.0 + self.height.0);
+        let bottom = self.y;
         let left = self.x;
         let right = Pt(self.x.0 + self.width.0);
 


### PR DESCRIPTION
The to_polygon method for Rect was incorrectly calculating the top and bottom y-coordinates, treating the provided y as the top-left instead of the bottom-left corner.

This commit corrects the calculation in the `gen_points` method to align with the documentation and user expectation, ensuring rectangles are placed correctly when converted to polygons.

Fixes #233