### PR TITLE
Fix DOCINFO fields encoding to use UTF-16BE format

### DIFF
--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -1243,9 +1243,7 @@ fn docinfo_to_dict(m: &PdfDocumentInfo) -> LoDictionary {
     let info_create_date = crate::utils::to_pdf_time_stamp_metadata(&m.creation_date);
 
     let creation_date = LoString(info_create_date.into_bytes(), Literal);
-    let title = LoString(m.document_title.to_string().as_bytes().to_vec(), Literal);
     let identifier = LoString(m.identifier.as_bytes().to_vec(), Literal);
-    let keywords = LoString(m.keywords.join(",").as_bytes().to_vec(), Literal);
 
     LoDictionary::from_iter(vec![
         ("Trapped", trapping.into()),
@@ -1255,16 +1253,13 @@ fn docinfo_to_dict(m: &PdfDocumentInfo) -> LoDictionary {
             "GTS_PDFXVersion",
             LoString(gts_pdfx_version.into(), Literal),
         ),
-        ("Title", title),
-        ("Author", LoString(m.author.as_bytes().to_vec(), Literal)),
-        ("Creator", LoString(m.creator.as_bytes().to_vec(), Literal)),
-        (
-            "Producer",
-            LoString(m.producer.as_bytes().to_vec(), Literal),
-        ),
-        ("Subject", LoString(m.subject.as_bytes().to_vec(), Literal)),
+        ("Title", encode_text_to_utf16be(&m.document_title)),
+        ("Author", encode_text_to_utf16be(&m.author)),
+        ("Creator", encode_text_to_utf16be(&m.creator)),
+        ("Producer", encode_text_to_utf16be(&m.producer)),
+        ("Subject", encode_text_to_utf16be(&m.subject)),
         ("Identifier", identifier),
-        ("Keywords", keywords),
+        ("Keywords", encode_text_to_utf16be(&m.keywords.join(","))),
     ])
 }
 


### PR DESCRIPTION
## Summary
- Fix encoding of PDF DOCINFO text fields (Title, Author, Creator, Producer, Subject, Keywords) to use proper UTF-16BE format
- Replace previous byte-level encoding with UTF-16BE encoding that includes BOM (Byte Order Mark)
- Ensures proper Unicode character support in PDF metadata fields

## Changes
- Modified `docinfo_to_dict()` function in `src/serialize.rs` to use `encode_text_to_utf16be()` for text fields
- Removed manual byte conversion and replaced with proper UTF-16BE encoding function

## Test plan
- [ ] Verify that PDFs with Unicode characters in metadata fields are correctly generated
- [ ] Test that PDF readers can properly display Unicode metadata
- [ ] Ensure backward compatibility with existing PDF generation

🤖 Generated with [Claude Code](https://claude.ai/code)