### PR TITLE
Eliminate warnings in gif-only builds

### DIFF
--- a/src/deserialize.rs
+++ b/src/deserialize.rs
@@ -2497,7 +2497,7 @@ pub fn parse_op(
     op_id: usize,
     op: &lopdf::content::Operation,
     state: &mut PageState,
-    xobjects: &BTreeMap<XObjectId, XObject>,
+    _xobjects: &BTreeMap<XObjectId, XObject>,
     warnings: &mut Vec<PdfWarnMsg>,
 ) -> Result<Vec<Op>, String> {
     use crate::units::Pt;
@@ -5358,6 +5358,7 @@ mod parsefont {
     }
 
     /// Process a Type1 font
+    #[cfg(feature = "text_layout")]
     fn process_type1_font(
         doc: &Document,
         font_dict: &Dictionary,
@@ -5375,7 +5376,7 @@ mod parsefont {
 
     /// Process a standard font (Type1, TrueType, etc.)
     fn process_standard_font(
-        doc: &Document,
+        _doc: &Document,
         font_dict: &Dictionary,
         font_id: &FontId,
         warnings: &mut Vec<PdfWarnMsg>,
@@ -5393,7 +5394,7 @@ mod parsefont {
             None => {
                 #[cfg(feature = "text_layout")]
                 {
-                    match process_type1_font(doc, font_dict, font_id, warnings, page_num) {
+                    match process_type1_font(_doc, font_dict, font_id, warnings, page_num) {
                         Some(parsed_font) => {
                             Some(ParsedOrBuiltinFont::P(ParsedExternalFont {
                                 font: parsed_font,

--- a/src/image_types.rs
+++ b/src/image_types.rs
@@ -315,6 +315,7 @@ impl RawImage {
 /// crash. Alpha channels are split into a grayscale `/SMask` per the PDF spec;
 /// 16-bit and float data is downconverted to 8-bit (a fidelity loss, but a
 /// valid file — the `images` feature path keeps full depth).
+#[cfg(not(feature = "images"))]
 pub(crate) fn raw_image_to_basic_stream(
     im: &RawImage,
     doc: &mut lopdf::Document,

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -531,7 +531,7 @@ pub(crate) fn translate_operations(
     // the mistake is loud now.
     let mut in_text_section = false;
     let mut warned_outside_text_section = false;
-    let mut warn_outside = |op_idx: usize,
+    let warn_outside = |op_idx: usize,
                             op_name: &str,
                             warned: &mut bool,
                             warnings: &mut Vec<PdfWarnMsg>| {
@@ -1564,7 +1564,7 @@ fn rectangle_to_stream_ops(rectangle: &crate::Rect) -> Vec<LoOp> {
 pub(crate) fn prepare_fonts_for_serialization(
     resources: &PdfResources,
     pages: &[PdfPage],
-    do_subset: bool,
+    _do_subset: bool,
     warnings: &mut Vec<PdfWarnMsg>,
 ) -> (BTreeMap<FontId, RuntimeFontInfo>, BTreeMap<FontId, RuntimeSubsetInfo>) {
     let mut font_infos = BTreeMap::new();
@@ -1590,7 +1590,7 @@ pub(crate) fn prepare_fonts_for_serialization(
         
         // Create RuntimeSubsetInfo for font dictionary
         #[cfg(feature = "text_layout")]
-        let subset_info = if do_subset &&
+        let subset_info = if _do_subset &&
                              pdf_font.meta.requires_subsetting &&
                              pdf_font.meta.embedding_mode == crate::font::FontEmbeddingMode::Subset {
             // Try subsetting, fall back to full font if it fails

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -36,7 +36,10 @@
 //! let ops = layout_to_ops(&layout, page_height, &font_id, Color::black());
 //! ```
 
-use crate::{Color, FontId, Op, Pt, Rect, Rgb};
+use crate::{Color, FontId, Pt, Rect, Rgb};
+
+#[cfg(feature = "text_layout")]
+use crate::Op;
 
 #[cfg(feature = "text_layout")]
 use azul_layout::text3::{

--- a/src/text_boxes.rs
+++ b/src/text_boxes.rs
@@ -494,7 +494,7 @@ impl PdfPage {
         let font_id = font.id();
         let (asc_em, desc_em) = vertical_extent_em(parsed);
 
-        let mut emit = |st: &mut TextState,
+        let emit = |st: &mut TextState,
                         builder: &mut Builder,
                         text: &str,
                         adv_em: f32,

--- a/src/wasm/structs.rs
+++ b/src/wasm/structs.rs
@@ -53,7 +53,7 @@ pub fn html_to_document(input: HtmlToDocumentInput) -> Result<HtmlToDocumentOutp
 const ERR: &str = "Pdf_HtmlToDocument failed: feature --html not enabled for printpdf crate";
 
 #[cfg(not(feature = "html"))]
-pub fn html_to_document(input: HtmlToDocumentInput) -> Result<HtmlToDocumentOutput, String> {
+pub fn html_to_document(_input: HtmlToDocumentInput) -> Result<HtmlToDocumentOutput, String> {
     Err(ERR.to_string())
 }
 
@@ -76,7 +76,7 @@ pub async fn html_to_document_async(
 
 #[cfg(not(feature = "html"))]
 pub async fn html_to_document_async(
-    input: HtmlToDocumentInput,
+    _input: HtmlToDocumentInput,
 ) -> Result<HtmlToDocumentOutput, String> {
     Err(ERR.to_string())
 }
@@ -269,6 +269,7 @@ static REGISTERED_FONTS: std::sync::Mutex<BTreeMap<String, Vec<u8>>> =
     std::sync::Mutex::new(BTreeMap::new());
 
 /// Registry fonts (as `Raw`) overlaid with the call's own fonts.
+#[cfg(feature = "html")]
 pub(crate) fn fonts_with_registered(
     input_fonts: &BTreeMap<String, Base64OrRaw>,
 ) -> BTreeMap<String, Base64OrRaw> {


### PR DESCRIPTION
## Summary

Eliminate the compiler warnings produced by this reduced-feature build:

```console
cargo check --no-default-features --features gif
```

## Root cause

With default features disabled, `gif` enables the `images` feature but does not
enable `html` or `text_layout`. Several imports, helpers, and parameters were
therefore compiled in configurations where their consumers were absent.

Two closure bindings were also marked mutable even though the closures do not
mutate their captured state.

Together, these produced 11 unused-code and unnecessary-`mut` warnings.

## Changes

- Gate the `Op` import and Type 1 font helper on `text_layout`.
- Gate the registered-font merge helper on `html`.
- Compile the raw-image fallback encoder only when `images` is disabled, matching
  its existing call site.
- Prefix parameters that are intentionally unused in reduced-feature builds with
  underscores, while preserving their use in feature-enabled builds.
- Remove two unnecessary `mut` qualifiers.

No warning lints are suppressed, public signatures are unchanged, and runtime
behavior is preserved.

## Verification

All Cargo commands were run with `RUSTFLAGS="-D warnings"`:

```console
cargo check --no-default-features --features gif --all-targets
cargo check --no-default-features
cargo check --no-default-features --features images
cargo check --no-default-features --features text_layout
cargo check

cargo test --no-default-features --features gif
cargo test --no-default-features
cargo test --lib
```

`git diff --check` also passes.