### PR TITLE
release-prep 0.12.8: rust-fontconfig 5 + azul 0.0.15 (the pair)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## `0.12.8`
+
+**rust-fontconfig 5 + azul 0.0.15.** Font fallback in HTML→PDF now runs on
+rust-fontconfig 5's tiered `FontFallbackChain` (CSS families with per-script
+faces, script fallbacks, an explicit last resort) and its `FcFallbackConfig`
+generic-family model, through azul-layout 0.0.15. printpdf only uses the
+stable surface (`FcFontCache`, `FcPattern`/`FcFont`, `FcParseFontBytes`,
+`FontBytes`, `UnicodeRange`), so no printpdf code changed; the dependency
+range moved from `>=4.4.9, <5` to `>=5.0, <6`, intersecting azul-layout's
+`>=5.0, <5.1` on ONE rust-fontconfig (two copies would be two independent
+font caches: layout resolving a font the renderer cannot find). Verified
+against the azul tree at 865f63f47 (branch `feat/rust-fontconfig-5`): full
+default suite green, `html_font_resolution` and the ligature/subset canaries
+included; libazul (`build-dll`) built against this printpdf with ONE
+rust-fontconfig in the graph.
+
 ## `0.12.7`
 
 **PDF streams are actually compressed when `optimize` is on (#284).** The save

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,33 @@ the auto-closed #455): 199 tests over 33 binaries green, `html_font_resolution`
 and the ligature/subset canaries included, with ONE rust-fontconfig (5.0.0),
 one allsorts and one azul-core in the graph.
 
+**Font coverage is now exact, which changes fallback for the better.** No
+printpdf code changed, but rust-fontconfig 5 reads cmap segments directly
+instead of probing blocks, and that fixes two real defects in how the
+embedded base-14 fonts participated in per-character fallback:
+
+- **Symbol and ZapfDingbats reported NO coverage at all under rfc 4.** The
+  block probe could not read their cmap, so both declared empty
+  `unicode_ranges` — and azul skips empty-coverage faces during fallback, so
+  neither font could ever be chosen for any codepoint. They now declare the
+  43 and 10 codepoints they really map.
+- **Everyone else over-claimed.** Coverage was rounded up to the enclosing
+  block: Helvetica claimed all 256 of U+0000..=U+00FF against 213 real
+  glyphs, and Times-Italic claimed the whole Cyrillic block on the strength
+  of a handful of glyphs. Over-claiming is the harmful direction — the
+  resolver stops at the first font whose ranges contain the codepoint, so a
+  bogus claim wins the character and renders .notdef instead of falling
+  through to a font that has the glyph. Verified against the cmap tables:
+  all fourteen subsets now report exactly the codepoints that map to a
+  non-.notdef glyph.
+
+`build_font_pool(fonts, Some(&["monospace"]))` and friends also scan a wider
+superset than before (generic expansion now includes the per-script fallback
+candidates: 13 -> 27 fonts for `monospace`, 24 -> 63 for `sans-serif` on a
+typical macOS box). The filter is documented as a superset selector, not the
+final resolution, so this only means more fonts are available to fall back
+to; `Some(&[])` still scans nothing.
+
 ## `0.12.7`
 
 **PDF streams are actually compressed when `optimize` is on (#284).** The save

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## `0.12.8`
 
-**rust-fontconfig 5 + azul 0.0.15.** Font fallback in HTML→PDF now runs on
+**rust-fontconfig 5 + azul 0.0.16.** Font fallback in HTML→PDF now runs on
 rust-fontconfig 5's tiered `FontFallbackChain` (CSS families with per-script
 faces, script fallbacks, an explicit last resort) and its `FcFallbackConfig`
-generic-family model, through azul-layout 0.0.15. printpdf only uses the
+generic-family model, through azul-layout 0.0.16. printpdf only uses the
 stable surface (`FcFontCache`, `FcPattern`/`FcFont`, `FcParseFontBytes`,
 `FontBytes`, `UnicodeRange`), so no printpdf code changed; the dependency
 range moved from `>=4.4.9, <5` to `>=5.0, <6`, intersecting azul-layout's
@@ -42,6 +42,15 @@ candidates: 13 -> 27 fonts for `monospace`, 24 -> 63 for `sans-serif` on a
 typical macOS box). The filter is documented as a superset selector, not the
 final resolution, so this only means more fonts are available to fall back
 to; `Some(&[])` still scans nothing.
+
+The azul pin is 0.0.16, not 0.0.15. Building printpdf against the published
+0.0.15 surfaced two azul-layout defects that only printpdf's feature matrix
+reaches (it is the only consumer that builds azul-layout without `cpurender`
+and without `xml`, across all three wasm targets): `uuid` was pulled into
+every wasm build and refused to compile on `wasm32-unknown-unknown`, and
+`DocumentChangeset::apply_to_dom` called into the `xml`-gated `document_edit`
+from an ungated impl block, breaking `--no-default-features --features
+text_layout`. Both are fixed in azul-layout 0.0.16 (azul#465).
 
 ## `0.12.7`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,10 @@ stable surface (`FcFontCache`, `FcPattern`/`FcFont`, `FcParseFontBytes`,
 range moved from `>=4.4.9, <5` to `>=5.0, <6`, intersecting azul-layout's
 `>=5.0, <5.1` on ONE rust-fontconfig (two copies would be two independent
 font caches: layout resolving a font the renderer cannot find). Verified
-against the azul tree at 865f63f47 (branch `feat/rust-fontconfig-5`): full
-default suite green, `html_font_resolution` and the ligature/subset canaries
-included; libazul (`build-dll`) built against this printpdf with ONE
-rust-fontconfig in the graph.
+against azul#457 at 041e20eb6 (branch `feat/rust-fontconfig-5`, the rebase of
+the auto-closed #455): 199 tests over 33 binaries green, `html_font_resolution`
+and the ligature/subset canaries included, with ONE rust-fontconfig (5.0.0),
+one allsorts and one azul-core in the graph.
 
 ## `0.12.7`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,20 +87,22 @@ rust-fontconfig = { version = ">=5.0, <6", default-features = false, features = 
 xmlparser = { version = "0.13.6", default-features = false, optional = true }
 web-sys = { version = "0.3.77", optional = true, default-features = false, features = ["console", "ImageData", "Window", "Document", "Blob", "CanvasRenderingContext2d", "HtmlCanvasElement", "HtmlImageElement", "ImageBitmap", "BlobPropertyBag"]}
 wasm-bindgen-futures = { version = "0.4.50", optional = true, default-features = false }
-# 0.0.13, not git. `register_named_font_in_tier` / `MemoryFontTier` (the
-# fallback tier that lets the embedded base-14 fonts stand in for
-# serif/sans-serif/monospace without displacing installed fonts) landed after
-# 0.0.12 and `register_builtin_fonts` in src/html/mod.rs needs it, so this
-# tracked the azul git branch until 0.0.13 was published. It now is.
+# 0.0.15 = the rust-fontconfig 5 release of azul (azul#457). Both pins move
+# together or the graph carries two FcFontCaches — see the rust-fontconfig
+# note above. Published from crates.io, never a git rev: `cargo publish`
+# strips [patch], so anything that only builds under one is not publishable
+# (the "No [patch]" CI gate enforces this).
 #
 # All three must stay pinned to the SAME version: azul-layout reaches its
 # siblings by in-repo path, so mixing versions would put two incompatible
-# azul-cores in the graph. Bump them together or not at all.
+# azul-cores in the graph. Bump them together or not at all. On 0.0.x crates
+# a "0.0.15" requirement is EXACT, which is what that rule needs.
 #
-# azul 0.0.15 = the rust-fontconfig 5 release (see the rust-fontconfig note
-# above: both pins move together or the graph carries two FcFontCaches). On
-# 0.0.x crates a "0.0.15" requirement is EXACT, which is what the
-# same-version rule above needs.
+# The exactness has a cost worth knowing: azul's workspace [patch] redirects
+# THIS dependency to its own path crates so the dll links one azul-layout, and
+# an exact pin stops matching the moment azul bumps in-tree. That is why the
+# two repos release as a pair — azul-* publish first, printpdf follows, then
+# azul re-pins printpdf. Never paper over it with a [patch] here.
 azul-css = { version = "0.0.15", default-features = false, features = ["parser"], optional = true }
 azul-core = { version = "0.0.15", default-features = false, features = ["std"], optional = true }
 azul-layout = { version = "0.0.15", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,9 @@ rust-fontconfig = { version = ">=5.0, <6", default-features = false, features = 
 xmlparser = { version = "0.13.6", default-features = false, optional = true }
 web-sys = { version = "0.3.77", optional = true, default-features = false, features = ["console", "ImageData", "Window", "Document", "Blob", "CanvasRenderingContext2d", "HtmlCanvasElement", "HtmlImageElement", "ImageBitmap", "BlobPropertyBag"]}
 wasm-bindgen-futures = { version = "0.4.50", optional = true, default-features = false }
-# 0.0.15 = the rust-fontconfig 5 release of azul (azul#457). Both pins move
+# 0.0.16 = the rust-fontconfig 5 release of azul (azul#457); 0.0.15 was the
+# same migration but pulled `uuid` into every wasm build and left
+# DocumentChangeset::apply_to_dom ungated, so it never worked here. Both pins move
 # together or the graph carries two FcFontCaches — see the rust-fontconfig
 # note above. Published from crates.io, never a git rev: `cargo publish`
 # strips [patch], so anything that only builds under one is not publishable
@@ -96,16 +98,16 @@ wasm-bindgen-futures = { version = "0.4.50", optional = true, default-features =
 # All three must stay pinned to the SAME version: azul-layout reaches its
 # siblings by in-repo path, so mixing versions would put two incompatible
 # azul-cores in the graph. Bump them together or not at all. On 0.0.x crates
-# a "0.0.15" requirement is EXACT, which is what that rule needs.
+# a "0.0.16" requirement is EXACT, which is what that rule needs.
 #
 # The exactness has a cost worth knowing: azul's workspace [patch] redirects
 # THIS dependency to its own path crates so the dll links one azul-layout, and
 # an exact pin stops matching the moment azul bumps in-tree. That is why the
 # two repos release as a pair — azul-* publish first, printpdf follows, then
 # azul re-pins printpdf. Never paper over it with a [patch] here.
-azul-css = { version = "0.0.15", default-features = false, features = ["parser"], optional = true }
-azul-core = { version = "0.0.15", default-features = false, features = ["std"], optional = true }
-azul-layout = { version = "0.0.15", default-features = false, optional = true }
+azul-css = { version = "0.0.16", default-features = false, features = ["parser"], optional = true }
+azul-core = { version = "0.0.16", default-features = false, features = ["std"], optional = true }
+azul-layout = { version = "0.0.16", default-features = false, optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "printpdf"
-version = "0.12.7"
+version = "0.12.8"
 authors = [
     "Felix Schütt <felix.schuett@maps4print.com>",
     "Julien Schminke <julien.schminke@web.de",
@@ -74,11 +74,16 @@ flate2 = "1.0.35" # for decompression of builtin fonts
 serde_json = { version = "1" }
 smallvec = { version = "1.15.1", features = ["serde"] }
 # Feature-gated dependencies
-# Bounded below 4.5: 4.4.5 is the first release with a single allsorts 0.17 underneath —
-# 4.4.4 still carried allsorts 0.16, which linked two incompatible font parsers into
-# every build (the 0.11.1 headline fix; `only_one_allsorts_is_linked` guards the repo,
-# this bound guards consumers against an untested future 4.x drifting back).
-rust-fontconfig = { version = ">=4.4.9, <5", default-features = false, features = ["std", "parsing"], optional = true }
+# rust-fontconfig 5: the tiered FontFallbackChain (css groups with per-script
+# faces, script groups, last_resort) and the FcFallbackConfig generic-family
+# model that azul-layout 0.0.15 builds its font resolution on. printpdf only
+# touches the stable surface (FcFontCache, FcPattern/FcFont, FcParseFontBytes,
+# FontBytes, UnicodeRange), so no code changed — but the range MUST intersect
+# azul-layout's (`>=5.0, <5.1`) on one version: two rust-fontconfigs in one
+# binary are two independent FcFontCaches, i.e. layout resolving a font the
+# renderer cannot find. `only_one_allsorts_is_linked` still guards the repo
+# against a second allsorts underneath.
+rust-fontconfig = { version = ">=5.0, <6", default-features = false, features = ["std", "parsing"], optional = true }
 xmlparser = { version = "0.13.6", default-features = false, optional = true }
 web-sys = { version = "0.3.77", optional = true, default-features = false, features = ["console", "ImageData", "Window", "Document", "Blob", "CanvasRenderingContext2d", "HtmlCanvasElement", "HtmlImageElement", "ImageBitmap", "BlobPropertyBag"]}
 wasm-bindgen-futures = { version = "0.4.50", optional = true, default-features = false }
@@ -92,13 +97,13 @@ wasm-bindgen-futures = { version = "0.4.50", optional = true, default-features =
 # siblings by in-repo path, so mixing versions would put two incompatible
 # azul-cores in the graph. Bump them together or not at all.
 #
-# Published azul 0.0.14 (the release carrying the dense-text fixes this
-# crate's own ligature tests caught: the per-line y freeze and the
-# needs_detail byte-length gap). On 0.0.x crates a "0.0.14" requirement is
-# EXACT, which is what the same-version rule above needs.
-azul-css = { version = "0.0.14", default-features = false, features = ["parser"], optional = true }
-azul-core = { version = "0.0.14", default-features = false, features = ["std"], optional = true }
-azul-layout = { version = "0.0.14", default-features = false, optional = true }
+# azul 0.0.15 = the rust-fontconfig 5 release (see the rust-fontconfig note
+# above: both pins move together or the graph carries two FcFontCaches). On
+# 0.0.x crates a "0.0.15" requirement is EXACT, which is what the
+# same-version rule above needs.
+azul-css = { version = "0.0.15", default-features = false, features = ["parser"], optional = true }
+azul-core = { version = "0.0.15", default-features = false, features = ["std"], optional = true }
+azul-layout = { version = "0.0.15", default-features = false, optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/src/html/mod.rs
+++ b/src/html/mod.rs
@@ -1596,17 +1596,58 @@ mod builtin_font_tests {
         }
     }
 
-    /// These subsets only cover Win-1252, so they have to declare that honestly:
-    /// azul skips empty-`unicode_ranges` faces during per-character fallback, so
-    /// an unclaimed range is a codepoint that can never fall through elsewhere.
+    /// These subsets cover a little over 200 codepoints each, so they have to
+    /// declare that honestly: azul skips empty-`unicode_ranges` faces during
+    /// per-character fallback, so an unclaimed codepoint is one that can never
+    /// fall through elsewhere.
+    ///
+    /// All fourteen, not just Helvetica. Under rust-fontconfig 4 the cmap block
+    /// probe returned NOTHING for Symbol and ZapfDingbats — both were silently
+    /// unreachable through fallback while a Helvetica-only assertion passed —
+    /// and it rounded everyone else up to whole blocks, so Helvetica claimed all
+    /// of U+0000..=U+00FF (256) against 213 real glyphs and Times-Italic claimed
+    /// the entire Cyrillic block on the strength of a few glyphs. rust-fontconfig
+    /// 5 reads the cmap segments exactly; every face now reports precisely the
+    /// codepoints that map to a non-.notdef glyph.
     #[test]
-    fn registered_faces_carry_real_coverage() {
+    fn every_builtin_face_carries_real_coverage() {
         let fm = registered();
-        for face in faces(&fm, "Helvetica") {
-            assert!(
-                !face.font_match.unicode_ranges.is_empty(),
-                "coverage must come from the font, not be left empty"
-            );
+        for font in crate::BuiltinFont::all_ids() {
+            let registered = faces(&fm, font.get_id());
+            assert!(!registered.is_empty(), "{} is not registered at all", font.get_id());
+            for face in registered {
+                assert!(
+                    !face.font_match.unicode_ranges.is_empty(),
+                    "{} carries empty coverage - unreachable in per-character fallback",
+                    font.get_id()
+                );
+            }
         }
+    }
+
+    /// Coverage is exact, never rounded up to the enclosing block. A face that
+    /// over-claims is worse than one that under-claims: the resolver stops at
+    /// the first font whose ranges contain the codepoint, so a bogus claim
+    /// wins the character and renders .notdef instead of falling through to a
+    /// font that actually has the glyph. Helvetica's cmap holds 213 mapped
+    /// codepoints; block-rounding reported 256.
+    #[test]
+    fn builtin_coverage_is_exact_not_block_rounded() {
+        let fm = registered();
+        let face = faces(&fm, "Helvetica")
+            .iter()
+            .find(|f| !(f.italic || f.oblique) && f.weight < FcWeight::Bold)
+            .expect("regular Helvetica");
+        let covered: u32 = face
+            .font_match
+            .unicode_ranges
+            .iter()
+            .map(|r| r.end - r.start + 1)
+            .sum();
+        assert_eq!(
+            covered, 213,
+            "expected the 213 codepoints Helvetica.subset.ttf actually maps, got {covered} \
+             (256 means coverage was rounded up to the Latin-1 block again)"
+        );
     }
 }


### PR DESCRIPTION
Companion to fschutt/azul#455 (the azul side of the rust-fontconfig 5 migration). One commit.

## What

- `rust-fontconfig` `>=5.0, <6` (was `>=4.4.9, <5`).
- azul-css / azul-core / azul-layout pinned to `0.0.15` (the version azul#455 will publish; 0.0.14 pins rust-fontconfig 4).
- Version 0.12.8, CHANGELOG entry.

## Does not resolve until azul 0.0.15 is on crates.io - by design

printpdf <= 0.12.7 pinning azul `0.0.14` exactly is what forces two copies of rust-fontconfig into any consumer that also wants azul on rfc 5. This PR and azul#455 land as a pair:

1. azul publishes azul-css/core/layout 0.0.15 (rfc 5).
2. this PR publishes printpdf 0.12.8.
3. azul's dll re-pins printpdf 0.12.8 in the same commit that lands the migration.

## Verified

Against the azul tree at `865f63f47`/`e0c89738c` (`feat/rust-fontconfig-5`) via a temporary path patch (not committed): `cargo check --release --features html` clean, full default suite green including `html_font_resolution` and the ligature/subset canaries (`html_visual_subset_glyphs`), and libazul (`build-dll`) built against this printpdf with ONE rust-fontconfig in the graph.

Also surfaced by this build: two missing `cpurender` gates in azul-layout (fixed in azul#455) - printpdf's feature set (no cpurender) is the only configuration that compiles them without the renderer, and azul's CI matrix now checks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XBWkPsPiKd2bWevJzNwzJv